### PR TITLE
Use `rgb255` instead of `rgb`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ format-js:
 	prettier --single-quote --write generate.ts
 
 format: format-js
-	elm-format src/Colorbrewer --yes
+	./node_modules/.bin/elm-format src/Colorbrewer --yes
 

--- a/generate.ts
+++ b/generate.ts
@@ -13,7 +13,7 @@ const generateRgbColours = (cs: Array<string>): Array<string> =>
       .split(',')
       .map(string => parseInt(string))
       .join(' ');
-    return `rgb ${colors}`;
+    return `rgb255 ${colors}`;
   });
 
 const generateColorFile = (filename: string, colors) => {
@@ -91,7 +91,7 @@ Exposes ${filename} colors from colorbrewer.
 
 -}
 
-import Color exposing (Color, rgb)
+import Color exposing (Color, rgb255)
 
 ${colorElms.join('\n')}
 `;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/node": "^11.13.8",
+    "elm-format": "^0.8.1",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5"
   },

--- a/src/Colorbrewer/Diverging.elm
+++ b/src/Colorbrewer/Diverging.elm
@@ -6,4543 +6,4543 @@ module Colorbrewer.Diverging exposing (spectral3_0, spectral3_1, spectral3_2, sp
 
 -}
 
-import Color exposing (Color, rgb)
+import Color exposing (Color, rgb255)
 
 
 {-| Provides the Spectral3 color scheme.
 -}
 spectral3 : List Color
 spectral3 =
-    [ rgb 252 141 89, rgb 255 255 191, rgb 153 213 148 ]
+    [ rgb255 252 141 89, rgb255 255 255 191, rgb255 153 213 148 ]
 
 
 {-| Provides the Spectral3-0 color.
 -}
 spectral3_0 : Color
 spectral3_0 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the Spectral3-1 color.
 -}
 spectral3_1 : Color
 spectral3_1 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the Spectral3-2 color.
 -}
 spectral3_2 : Color
 spectral3_2 =
-    rgb 153 213 148
+    rgb255 153 213 148
 
 
 {-| Provides the Spectral4 color scheme.
 -}
 spectral4 : List Color
 spectral4 =
-    [ rgb 215 25 28, rgb 253 174 97, rgb 171 221 164, rgb 43 131 186 ]
+    [ rgb255 215 25 28, rgb255 253 174 97, rgb255 171 221 164, rgb255 43 131 186 ]
 
 
 {-| Provides the Spectral4-0 color.
 -}
 spectral4_0 : Color
 spectral4_0 =
-    rgb 215 25 28
+    rgb255 215 25 28
 
 
 {-| Provides the Spectral4-1 color.
 -}
 spectral4_1 : Color
 spectral4_1 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the Spectral4-2 color.
 -}
 spectral4_2 : Color
 spectral4_2 =
-    rgb 171 221 164
+    rgb255 171 221 164
 
 
 {-| Provides the Spectral4-3 color.
 -}
 spectral4_3 : Color
 spectral4_3 =
-    rgb 43 131 186
+    rgb255 43 131 186
 
 
 {-| Provides the Spectral5 color scheme.
 -}
 spectral5 : List Color
 spectral5 =
-    [ rgb 215 25 28, rgb 253 174 97, rgb 255 255 191, rgb 171 221 164, rgb 43 131 186 ]
+    [ rgb255 215 25 28, rgb255 253 174 97, rgb255 255 255 191, rgb255 171 221 164, rgb255 43 131 186 ]
 
 
 {-| Provides the Spectral5-0 color.
 -}
 spectral5_0 : Color
 spectral5_0 =
-    rgb 215 25 28
+    rgb255 215 25 28
 
 
 {-| Provides the Spectral5-1 color.
 -}
 spectral5_1 : Color
 spectral5_1 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the Spectral5-2 color.
 -}
 spectral5_2 : Color
 spectral5_2 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the Spectral5-3 color.
 -}
 spectral5_3 : Color
 spectral5_3 =
-    rgb 171 221 164
+    rgb255 171 221 164
 
 
 {-| Provides the Spectral5-4 color.
 -}
 spectral5_4 : Color
 spectral5_4 =
-    rgb 43 131 186
+    rgb255 43 131 186
 
 
 {-| Provides the Spectral6 color scheme.
 -}
 spectral6 : List Color
 spectral6 =
-    [ rgb 213 62 79, rgb 252 141 89, rgb 254 224 139, rgb 230 245 152, rgb 153 213 148, rgb 50 136 189 ]
+    [ rgb255 213 62 79, rgb255 252 141 89, rgb255 254 224 139, rgb255 230 245 152, rgb255 153 213 148, rgb255 50 136 189 ]
 
 
 {-| Provides the Spectral6-0 color.
 -}
 spectral6_0 : Color
 spectral6_0 =
-    rgb 213 62 79
+    rgb255 213 62 79
 
 
 {-| Provides the Spectral6-1 color.
 -}
 spectral6_1 : Color
 spectral6_1 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the Spectral6-2 color.
 -}
 spectral6_2 : Color
 spectral6_2 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the Spectral6-3 color.
 -}
 spectral6_3 : Color
 spectral6_3 =
-    rgb 230 245 152
+    rgb255 230 245 152
 
 
 {-| Provides the Spectral6-4 color.
 -}
 spectral6_4 : Color
 spectral6_4 =
-    rgb 153 213 148
+    rgb255 153 213 148
 
 
 {-| Provides the Spectral6-5 color.
 -}
 spectral6_5 : Color
 spectral6_5 =
-    rgb 50 136 189
+    rgb255 50 136 189
 
 
 {-| Provides the Spectral7 color scheme.
 -}
 spectral7 : List Color
 spectral7 =
-    [ rgb 213 62 79, rgb 252 141 89, rgb 254 224 139, rgb 255 255 191, rgb 230 245 152, rgb 153 213 148, rgb 50 136 189 ]
+    [ rgb255 213 62 79, rgb255 252 141 89, rgb255 254 224 139, rgb255 255 255 191, rgb255 230 245 152, rgb255 153 213 148, rgb255 50 136 189 ]
 
 
 {-| Provides the Spectral7-0 color.
 -}
 spectral7_0 : Color
 spectral7_0 =
-    rgb 213 62 79
+    rgb255 213 62 79
 
 
 {-| Provides the Spectral7-1 color.
 -}
 spectral7_1 : Color
 spectral7_1 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the Spectral7-2 color.
 -}
 spectral7_2 : Color
 spectral7_2 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the Spectral7-3 color.
 -}
 spectral7_3 : Color
 spectral7_3 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the Spectral7-4 color.
 -}
 spectral7_4 : Color
 spectral7_4 =
-    rgb 230 245 152
+    rgb255 230 245 152
 
 
 {-| Provides the Spectral7-5 color.
 -}
 spectral7_5 : Color
 spectral7_5 =
-    rgb 153 213 148
+    rgb255 153 213 148
 
 
 {-| Provides the Spectral7-6 color.
 -}
 spectral7_6 : Color
 spectral7_6 =
-    rgb 50 136 189
+    rgb255 50 136 189
 
 
 {-| Provides the Spectral8 color scheme.
 -}
 spectral8 : List Color
 spectral8 =
-    [ rgb 213 62 79, rgb 244 109 67, rgb 253 174 97, rgb 254 224 139, rgb 230 245 152, rgb 171 221 164, rgb 102 194 165, rgb 50 136 189 ]
+    [ rgb255 213 62 79, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 139, rgb255 230 245 152, rgb255 171 221 164, rgb255 102 194 165, rgb255 50 136 189 ]
 
 
 {-| Provides the Spectral8-0 color.
 -}
 spectral8_0 : Color
 spectral8_0 =
-    rgb 213 62 79
+    rgb255 213 62 79
 
 
 {-| Provides the Spectral8-1 color.
 -}
 spectral8_1 : Color
 spectral8_1 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the Spectral8-2 color.
 -}
 spectral8_2 : Color
 spectral8_2 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the Spectral8-3 color.
 -}
 spectral8_3 : Color
 spectral8_3 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the Spectral8-4 color.
 -}
 spectral8_4 : Color
 spectral8_4 =
-    rgb 230 245 152
+    rgb255 230 245 152
 
 
 {-| Provides the Spectral8-5 color.
 -}
 spectral8_5 : Color
 spectral8_5 =
-    rgb 171 221 164
+    rgb255 171 221 164
 
 
 {-| Provides the Spectral8-6 color.
 -}
 spectral8_6 : Color
 spectral8_6 =
-    rgb 102 194 165
+    rgb255 102 194 165
 
 
 {-| Provides the Spectral8-7 color.
 -}
 spectral8_7 : Color
 spectral8_7 =
-    rgb 50 136 189
+    rgb255 50 136 189
 
 
 {-| Provides the Spectral9 color scheme.
 -}
 spectral9 : List Color
 spectral9 =
-    [ rgb 213 62 79, rgb 244 109 67, rgb 253 174 97, rgb 254 224 139, rgb 255 255 191, rgb 230 245 152, rgb 171 221 164, rgb 102 194 165, rgb 50 136 189 ]
+    [ rgb255 213 62 79, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 139, rgb255 255 255 191, rgb255 230 245 152, rgb255 171 221 164, rgb255 102 194 165, rgb255 50 136 189 ]
 
 
 {-| Provides the Spectral9-0 color.
 -}
 spectral9_0 : Color
 spectral9_0 =
-    rgb 213 62 79
+    rgb255 213 62 79
 
 
 {-| Provides the Spectral9-1 color.
 -}
 spectral9_1 : Color
 spectral9_1 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the Spectral9-2 color.
 -}
 spectral9_2 : Color
 spectral9_2 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the Spectral9-3 color.
 -}
 spectral9_3 : Color
 spectral9_3 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the Spectral9-4 color.
 -}
 spectral9_4 : Color
 spectral9_4 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the Spectral9-5 color.
 -}
 spectral9_5 : Color
 spectral9_5 =
-    rgb 230 245 152
+    rgb255 230 245 152
 
 
 {-| Provides the Spectral9-6 color.
 -}
 spectral9_6 : Color
 spectral9_6 =
-    rgb 171 221 164
+    rgb255 171 221 164
 
 
 {-| Provides the Spectral9-7 color.
 -}
 spectral9_7 : Color
 spectral9_7 =
-    rgb 102 194 165
+    rgb255 102 194 165
 
 
 {-| Provides the Spectral9-8 color.
 -}
 spectral9_8 : Color
 spectral9_8 =
-    rgb 50 136 189
+    rgb255 50 136 189
 
 
 {-| Provides the Spectral10 color scheme.
 -}
 spectral10 : List Color
 spectral10 =
-    [ rgb 158 1 66, rgb 213 62 79, rgb 244 109 67, rgb 253 174 97, rgb 254 224 139, rgb 230 245 152, rgb 171 221 164, rgb 102 194 165, rgb 50 136 189, rgb 94 79 162 ]
+    [ rgb255 158 1 66, rgb255 213 62 79, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 139, rgb255 230 245 152, rgb255 171 221 164, rgb255 102 194 165, rgb255 50 136 189, rgb255 94 79 162 ]
 
 
 {-| Provides the Spectral10-0 color.
 -}
 spectral10_0 : Color
 spectral10_0 =
-    rgb 158 1 66
+    rgb255 158 1 66
 
 
 {-| Provides the Spectral10-1 color.
 -}
 spectral10_1 : Color
 spectral10_1 =
-    rgb 213 62 79
+    rgb255 213 62 79
 
 
 {-| Provides the Spectral10-2 color.
 -}
 spectral10_2 : Color
 spectral10_2 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the Spectral10-3 color.
 -}
 spectral10_3 : Color
 spectral10_3 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the Spectral10-4 color.
 -}
 spectral10_4 : Color
 spectral10_4 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the Spectral10-5 color.
 -}
 spectral10_5 : Color
 spectral10_5 =
-    rgb 230 245 152
+    rgb255 230 245 152
 
 
 {-| Provides the Spectral10-6 color.
 -}
 spectral10_6 : Color
 spectral10_6 =
-    rgb 171 221 164
+    rgb255 171 221 164
 
 
 {-| Provides the Spectral10-7 color.
 -}
 spectral10_7 : Color
 spectral10_7 =
-    rgb 102 194 165
+    rgb255 102 194 165
 
 
 {-| Provides the Spectral10-8 color.
 -}
 spectral10_8 : Color
 spectral10_8 =
-    rgb 50 136 189
+    rgb255 50 136 189
 
 
 {-| Provides the Spectral10-9 color.
 -}
 spectral10_9 : Color
 spectral10_9 =
-    rgb 94 79 162
+    rgb255 94 79 162
 
 
 {-| Provides the Spectral11 color scheme.
 -}
 spectral11 : List Color
 spectral11 =
-    [ rgb 158 1 66, rgb 213 62 79, rgb 244 109 67, rgb 253 174 97, rgb 254 224 139, rgb 255 255 191, rgb 230 245 152, rgb 171 221 164, rgb 102 194 165, rgb 50 136 189, rgb 94 79 162 ]
+    [ rgb255 158 1 66, rgb255 213 62 79, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 139, rgb255 255 255 191, rgb255 230 245 152, rgb255 171 221 164, rgb255 102 194 165, rgb255 50 136 189, rgb255 94 79 162 ]
 
 
 {-| Provides the Spectral11-0 color.
 -}
 spectral11_0 : Color
 spectral11_0 =
-    rgb 158 1 66
+    rgb255 158 1 66
 
 
 {-| Provides the Spectral11-1 color.
 -}
 spectral11_1 : Color
 spectral11_1 =
-    rgb 213 62 79
+    rgb255 213 62 79
 
 
 {-| Provides the Spectral11-2 color.
 -}
 spectral11_2 : Color
 spectral11_2 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the Spectral11-3 color.
 -}
 spectral11_3 : Color
 spectral11_3 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the Spectral11-4 color.
 -}
 spectral11_4 : Color
 spectral11_4 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the Spectral11-5 color.
 -}
 spectral11_5 : Color
 spectral11_5 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the Spectral11-6 color.
 -}
 spectral11_6 : Color
 spectral11_6 =
-    rgb 230 245 152
+    rgb255 230 245 152
 
 
 {-| Provides the Spectral11-7 color.
 -}
 spectral11_7 : Color
 spectral11_7 =
-    rgb 171 221 164
+    rgb255 171 221 164
 
 
 {-| Provides the Spectral11-8 color.
 -}
 spectral11_8 : Color
 spectral11_8 =
-    rgb 102 194 165
+    rgb255 102 194 165
 
 
 {-| Provides the Spectral11-9 color.
 -}
 spectral11_9 : Color
 spectral11_9 =
-    rgb 50 136 189
+    rgb255 50 136 189
 
 
 {-| Provides the Spectral11-10 color.
 -}
 spectral11_10 : Color
 spectral11_10 =
-    rgb 94 79 162
+    rgb255 94 79 162
 
 
 {-| Provides the RdYlGn3 color scheme.
 -}
 rdylgn3 : List Color
 rdylgn3 =
-    [ rgb 252 141 89, rgb 255 255 191, rgb 145 207 96 ]
+    [ rgb255 252 141 89, rgb255 255 255 191, rgb255 145 207 96 ]
 
 
 {-| Provides the RdYlGn3-0 color.
 -}
 rdylgn3_0 : Color
 rdylgn3_0 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the RdYlGn3-1 color.
 -}
 rdylgn3_1 : Color
 rdylgn3_1 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the RdYlGn3-2 color.
 -}
 rdylgn3_2 : Color
 rdylgn3_2 =
-    rgb 145 207 96
+    rgb255 145 207 96
 
 
 {-| Provides the RdYlGn4 color scheme.
 -}
 rdylgn4 : List Color
 rdylgn4 =
-    [ rgb 215 25 28, rgb 253 174 97, rgb 166 217 106, rgb 26 150 65 ]
+    [ rgb255 215 25 28, rgb255 253 174 97, rgb255 166 217 106, rgb255 26 150 65 ]
 
 
 {-| Provides the RdYlGn4-0 color.
 -}
 rdylgn4_0 : Color
 rdylgn4_0 =
-    rgb 215 25 28
+    rgb255 215 25 28
 
 
 {-| Provides the RdYlGn4-1 color.
 -}
 rdylgn4_1 : Color
 rdylgn4_1 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlGn4-2 color.
 -}
 rdylgn4_2 : Color
 rdylgn4_2 =
-    rgb 166 217 106
+    rgb255 166 217 106
 
 
 {-| Provides the RdYlGn4-3 color.
 -}
 rdylgn4_3 : Color
 rdylgn4_3 =
-    rgb 26 150 65
+    rgb255 26 150 65
 
 
 {-| Provides the RdYlGn5 color scheme.
 -}
 rdylgn5 : List Color
 rdylgn5 =
-    [ rgb 215 25 28, rgb 253 174 97, rgb 255 255 191, rgb 166 217 106, rgb 26 150 65 ]
+    [ rgb255 215 25 28, rgb255 253 174 97, rgb255 255 255 191, rgb255 166 217 106, rgb255 26 150 65 ]
 
 
 {-| Provides the RdYlGn5-0 color.
 -}
 rdylgn5_0 : Color
 rdylgn5_0 =
-    rgb 215 25 28
+    rgb255 215 25 28
 
 
 {-| Provides the RdYlGn5-1 color.
 -}
 rdylgn5_1 : Color
 rdylgn5_1 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlGn5-2 color.
 -}
 rdylgn5_2 : Color
 rdylgn5_2 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the RdYlGn5-3 color.
 -}
 rdylgn5_3 : Color
 rdylgn5_3 =
-    rgb 166 217 106
+    rgb255 166 217 106
 
 
 {-| Provides the RdYlGn5-4 color.
 -}
 rdylgn5_4 : Color
 rdylgn5_4 =
-    rgb 26 150 65
+    rgb255 26 150 65
 
 
 {-| Provides the RdYlGn6 color scheme.
 -}
 rdylgn6 : List Color
 rdylgn6 =
-    [ rgb 215 48 39, rgb 252 141 89, rgb 254 224 139, rgb 217 239 139, rgb 145 207 96, rgb 26 152 80 ]
+    [ rgb255 215 48 39, rgb255 252 141 89, rgb255 254 224 139, rgb255 217 239 139, rgb255 145 207 96, rgb255 26 152 80 ]
 
 
 {-| Provides the RdYlGn6-0 color.
 -}
 rdylgn6_0 : Color
 rdylgn6_0 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlGn6-1 color.
 -}
 rdylgn6_1 : Color
 rdylgn6_1 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the RdYlGn6-2 color.
 -}
 rdylgn6_2 : Color
 rdylgn6_2 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the RdYlGn6-3 color.
 -}
 rdylgn6_3 : Color
 rdylgn6_3 =
-    rgb 217 239 139
+    rgb255 217 239 139
 
 
 {-| Provides the RdYlGn6-4 color.
 -}
 rdylgn6_4 : Color
 rdylgn6_4 =
-    rgb 145 207 96
+    rgb255 145 207 96
 
 
 {-| Provides the RdYlGn6-5 color.
 -}
 rdylgn6_5 : Color
 rdylgn6_5 =
-    rgb 26 152 80
+    rgb255 26 152 80
 
 
 {-| Provides the RdYlGn7 color scheme.
 -}
 rdylgn7 : List Color
 rdylgn7 =
-    [ rgb 215 48 39, rgb 252 141 89, rgb 254 224 139, rgb 255 255 191, rgb 217 239 139, rgb 145 207 96, rgb 26 152 80 ]
+    [ rgb255 215 48 39, rgb255 252 141 89, rgb255 254 224 139, rgb255 255 255 191, rgb255 217 239 139, rgb255 145 207 96, rgb255 26 152 80 ]
 
 
 {-| Provides the RdYlGn7-0 color.
 -}
 rdylgn7_0 : Color
 rdylgn7_0 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlGn7-1 color.
 -}
 rdylgn7_1 : Color
 rdylgn7_1 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the RdYlGn7-2 color.
 -}
 rdylgn7_2 : Color
 rdylgn7_2 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the RdYlGn7-3 color.
 -}
 rdylgn7_3 : Color
 rdylgn7_3 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the RdYlGn7-4 color.
 -}
 rdylgn7_4 : Color
 rdylgn7_4 =
-    rgb 217 239 139
+    rgb255 217 239 139
 
 
 {-| Provides the RdYlGn7-5 color.
 -}
 rdylgn7_5 : Color
 rdylgn7_5 =
-    rgb 145 207 96
+    rgb255 145 207 96
 
 
 {-| Provides the RdYlGn7-6 color.
 -}
 rdylgn7_6 : Color
 rdylgn7_6 =
-    rgb 26 152 80
+    rgb255 26 152 80
 
 
 {-| Provides the RdYlGn8 color scheme.
 -}
 rdylgn8 : List Color
 rdylgn8 =
-    [ rgb 215 48 39, rgb 244 109 67, rgb 253 174 97, rgb 254 224 139, rgb 217 239 139, rgb 166 217 106, rgb 102 189 99, rgb 26 152 80 ]
+    [ rgb255 215 48 39, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 139, rgb255 217 239 139, rgb255 166 217 106, rgb255 102 189 99, rgb255 26 152 80 ]
 
 
 {-| Provides the RdYlGn8-0 color.
 -}
 rdylgn8_0 : Color
 rdylgn8_0 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlGn8-1 color.
 -}
 rdylgn8_1 : Color
 rdylgn8_1 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the RdYlGn8-2 color.
 -}
 rdylgn8_2 : Color
 rdylgn8_2 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlGn8-3 color.
 -}
 rdylgn8_3 : Color
 rdylgn8_3 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the RdYlGn8-4 color.
 -}
 rdylgn8_4 : Color
 rdylgn8_4 =
-    rgb 217 239 139
+    rgb255 217 239 139
 
 
 {-| Provides the RdYlGn8-5 color.
 -}
 rdylgn8_5 : Color
 rdylgn8_5 =
-    rgb 166 217 106
+    rgb255 166 217 106
 
 
 {-| Provides the RdYlGn8-6 color.
 -}
 rdylgn8_6 : Color
 rdylgn8_6 =
-    rgb 102 189 99
+    rgb255 102 189 99
 
 
 {-| Provides the RdYlGn8-7 color.
 -}
 rdylgn8_7 : Color
 rdylgn8_7 =
-    rgb 26 152 80
+    rgb255 26 152 80
 
 
 {-| Provides the RdYlGn9 color scheme.
 -}
 rdylgn9 : List Color
 rdylgn9 =
-    [ rgb 215 48 39, rgb 244 109 67, rgb 253 174 97, rgb 254 224 139, rgb 255 255 191, rgb 217 239 139, rgb 166 217 106, rgb 102 189 99, rgb 26 152 80 ]
+    [ rgb255 215 48 39, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 139, rgb255 255 255 191, rgb255 217 239 139, rgb255 166 217 106, rgb255 102 189 99, rgb255 26 152 80 ]
 
 
 {-| Provides the RdYlGn9-0 color.
 -}
 rdylgn9_0 : Color
 rdylgn9_0 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlGn9-1 color.
 -}
 rdylgn9_1 : Color
 rdylgn9_1 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the RdYlGn9-2 color.
 -}
 rdylgn9_2 : Color
 rdylgn9_2 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlGn9-3 color.
 -}
 rdylgn9_3 : Color
 rdylgn9_3 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the RdYlGn9-4 color.
 -}
 rdylgn9_4 : Color
 rdylgn9_4 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the RdYlGn9-5 color.
 -}
 rdylgn9_5 : Color
 rdylgn9_5 =
-    rgb 217 239 139
+    rgb255 217 239 139
 
 
 {-| Provides the RdYlGn9-6 color.
 -}
 rdylgn9_6 : Color
 rdylgn9_6 =
-    rgb 166 217 106
+    rgb255 166 217 106
 
 
 {-| Provides the RdYlGn9-7 color.
 -}
 rdylgn9_7 : Color
 rdylgn9_7 =
-    rgb 102 189 99
+    rgb255 102 189 99
 
 
 {-| Provides the RdYlGn9-8 color.
 -}
 rdylgn9_8 : Color
 rdylgn9_8 =
-    rgb 26 152 80
+    rgb255 26 152 80
 
 
 {-| Provides the RdYlGn10 color scheme.
 -}
 rdylgn10 : List Color
 rdylgn10 =
-    [ rgb 165 0 38, rgb 215 48 39, rgb 244 109 67, rgb 253 174 97, rgb 254 224 139, rgb 217 239 139, rgb 166 217 106, rgb 102 189 99, rgb 26 152 80, rgb 0 104 55 ]
+    [ rgb255 165 0 38, rgb255 215 48 39, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 139, rgb255 217 239 139, rgb255 166 217 106, rgb255 102 189 99, rgb255 26 152 80, rgb255 0 104 55 ]
 
 
 {-| Provides the RdYlGn10-0 color.
 -}
 rdylgn10_0 : Color
 rdylgn10_0 =
-    rgb 165 0 38
+    rgb255 165 0 38
 
 
 {-| Provides the RdYlGn10-1 color.
 -}
 rdylgn10_1 : Color
 rdylgn10_1 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlGn10-2 color.
 -}
 rdylgn10_2 : Color
 rdylgn10_2 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the RdYlGn10-3 color.
 -}
 rdylgn10_3 : Color
 rdylgn10_3 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlGn10-4 color.
 -}
 rdylgn10_4 : Color
 rdylgn10_4 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the RdYlGn10-5 color.
 -}
 rdylgn10_5 : Color
 rdylgn10_5 =
-    rgb 217 239 139
+    rgb255 217 239 139
 
 
 {-| Provides the RdYlGn10-6 color.
 -}
 rdylgn10_6 : Color
 rdylgn10_6 =
-    rgb 166 217 106
+    rgb255 166 217 106
 
 
 {-| Provides the RdYlGn10-7 color.
 -}
 rdylgn10_7 : Color
 rdylgn10_7 =
-    rgb 102 189 99
+    rgb255 102 189 99
 
 
 {-| Provides the RdYlGn10-8 color.
 -}
 rdylgn10_8 : Color
 rdylgn10_8 =
-    rgb 26 152 80
+    rgb255 26 152 80
 
 
 {-| Provides the RdYlGn10-9 color.
 -}
 rdylgn10_9 : Color
 rdylgn10_9 =
-    rgb 0 104 55
+    rgb255 0 104 55
 
 
 {-| Provides the RdYlGn11 color scheme.
 -}
 rdylgn11 : List Color
 rdylgn11 =
-    [ rgb 165 0 38, rgb 215 48 39, rgb 244 109 67, rgb 253 174 97, rgb 254 224 139, rgb 255 255 191, rgb 217 239 139, rgb 166 217 106, rgb 102 189 99, rgb 26 152 80, rgb 0 104 55 ]
+    [ rgb255 165 0 38, rgb255 215 48 39, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 139, rgb255 255 255 191, rgb255 217 239 139, rgb255 166 217 106, rgb255 102 189 99, rgb255 26 152 80, rgb255 0 104 55 ]
 
 
 {-| Provides the RdYlGn11-0 color.
 -}
 rdylgn11_0 : Color
 rdylgn11_0 =
-    rgb 165 0 38
+    rgb255 165 0 38
 
 
 {-| Provides the RdYlGn11-1 color.
 -}
 rdylgn11_1 : Color
 rdylgn11_1 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlGn11-2 color.
 -}
 rdylgn11_2 : Color
 rdylgn11_2 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the RdYlGn11-3 color.
 -}
 rdylgn11_3 : Color
 rdylgn11_3 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlGn11-4 color.
 -}
 rdylgn11_4 : Color
 rdylgn11_4 =
-    rgb 254 224 139
+    rgb255 254 224 139
 
 
 {-| Provides the RdYlGn11-5 color.
 -}
 rdylgn11_5 : Color
 rdylgn11_5 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the RdYlGn11-6 color.
 -}
 rdylgn11_6 : Color
 rdylgn11_6 =
-    rgb 217 239 139
+    rgb255 217 239 139
 
 
 {-| Provides the RdYlGn11-7 color.
 -}
 rdylgn11_7 : Color
 rdylgn11_7 =
-    rgb 166 217 106
+    rgb255 166 217 106
 
 
 {-| Provides the RdYlGn11-8 color.
 -}
 rdylgn11_8 : Color
 rdylgn11_8 =
-    rgb 102 189 99
+    rgb255 102 189 99
 
 
 {-| Provides the RdYlGn11-9 color.
 -}
 rdylgn11_9 : Color
 rdylgn11_9 =
-    rgb 26 152 80
+    rgb255 26 152 80
 
 
 {-| Provides the RdYlGn11-10 color.
 -}
 rdylgn11_10 : Color
 rdylgn11_10 =
-    rgb 0 104 55
+    rgb255 0 104 55
 
 
 {-| Provides the RdBu3 color scheme.
 -}
 rdbu3 : List Color
 rdbu3 =
-    [ rgb 239 138 98, rgb 247 247 247, rgb 103 169 207 ]
+    [ rgb255 239 138 98, rgb255 247 247 247, rgb255 103 169 207 ]
 
 
 {-| Provides the RdBu3-0 color.
 -}
 rdbu3_0 : Color
 rdbu3_0 =
-    rgb 239 138 98
+    rgb255 239 138 98
 
 
 {-| Provides the RdBu3-1 color.
 -}
 rdbu3_1 : Color
 rdbu3_1 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the RdBu3-2 color.
 -}
 rdbu3_2 : Color
 rdbu3_2 =
-    rgb 103 169 207
+    rgb255 103 169 207
 
 
 {-| Provides the RdBu4 color scheme.
 -}
 rdbu4 : List Color
 rdbu4 =
-    [ rgb 202 0 32, rgb 244 165 130, rgb 146 197 222, rgb 5 113 176 ]
+    [ rgb255 202 0 32, rgb255 244 165 130, rgb255 146 197 222, rgb255 5 113 176 ]
 
 
 {-| Provides the RdBu4-0 color.
 -}
 rdbu4_0 : Color
 rdbu4_0 =
-    rgb 202 0 32
+    rgb255 202 0 32
 
 
 {-| Provides the RdBu4-1 color.
 -}
 rdbu4_1 : Color
 rdbu4_1 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdBu4-2 color.
 -}
 rdbu4_2 : Color
 rdbu4_2 =
-    rgb 146 197 222
+    rgb255 146 197 222
 
 
 {-| Provides the RdBu4-3 color.
 -}
 rdbu4_3 : Color
 rdbu4_3 =
-    rgb 5 113 176
+    rgb255 5 113 176
 
 
 {-| Provides the RdBu5 color scheme.
 -}
 rdbu5 : List Color
 rdbu5 =
-    [ rgb 202 0 32, rgb 244 165 130, rgb 247 247 247, rgb 146 197 222, rgb 5 113 176 ]
+    [ rgb255 202 0 32, rgb255 244 165 130, rgb255 247 247 247, rgb255 146 197 222, rgb255 5 113 176 ]
 
 
 {-| Provides the RdBu5-0 color.
 -}
 rdbu5_0 : Color
 rdbu5_0 =
-    rgb 202 0 32
+    rgb255 202 0 32
 
 
 {-| Provides the RdBu5-1 color.
 -}
 rdbu5_1 : Color
 rdbu5_1 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdBu5-2 color.
 -}
 rdbu5_2 : Color
 rdbu5_2 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the RdBu5-3 color.
 -}
 rdbu5_3 : Color
 rdbu5_3 =
-    rgb 146 197 222
+    rgb255 146 197 222
 
 
 {-| Provides the RdBu5-4 color.
 -}
 rdbu5_4 : Color
 rdbu5_4 =
-    rgb 5 113 176
+    rgb255 5 113 176
 
 
 {-| Provides the RdBu6 color scheme.
 -}
 rdbu6 : List Color
 rdbu6 =
-    [ rgb 178 24 43, rgb 239 138 98, rgb 253 219 199, rgb 209 229 240, rgb 103 169 207, rgb 33 102 172 ]
+    [ rgb255 178 24 43, rgb255 239 138 98, rgb255 253 219 199, rgb255 209 229 240, rgb255 103 169 207, rgb255 33 102 172 ]
 
 
 {-| Provides the RdBu6-0 color.
 -}
 rdbu6_0 : Color
 rdbu6_0 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdBu6-1 color.
 -}
 rdbu6_1 : Color
 rdbu6_1 =
-    rgb 239 138 98
+    rgb255 239 138 98
 
 
 {-| Provides the RdBu6-2 color.
 -}
 rdbu6_2 : Color
 rdbu6_2 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdBu6-3 color.
 -}
 rdbu6_3 : Color
 rdbu6_3 =
-    rgb 209 229 240
+    rgb255 209 229 240
 
 
 {-| Provides the RdBu6-4 color.
 -}
 rdbu6_4 : Color
 rdbu6_4 =
-    rgb 103 169 207
+    rgb255 103 169 207
 
 
 {-| Provides the RdBu6-5 color.
 -}
 rdbu6_5 : Color
 rdbu6_5 =
-    rgb 33 102 172
+    rgb255 33 102 172
 
 
 {-| Provides the RdBu7 color scheme.
 -}
 rdbu7 : List Color
 rdbu7 =
-    [ rgb 178 24 43, rgb 239 138 98, rgb 253 219 199, rgb 247 247 247, rgb 209 229 240, rgb 103 169 207, rgb 33 102 172 ]
+    [ rgb255 178 24 43, rgb255 239 138 98, rgb255 253 219 199, rgb255 247 247 247, rgb255 209 229 240, rgb255 103 169 207, rgb255 33 102 172 ]
 
 
 {-| Provides the RdBu7-0 color.
 -}
 rdbu7_0 : Color
 rdbu7_0 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdBu7-1 color.
 -}
 rdbu7_1 : Color
 rdbu7_1 =
-    rgb 239 138 98
+    rgb255 239 138 98
 
 
 {-| Provides the RdBu7-2 color.
 -}
 rdbu7_2 : Color
 rdbu7_2 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdBu7-3 color.
 -}
 rdbu7_3 : Color
 rdbu7_3 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the RdBu7-4 color.
 -}
 rdbu7_4 : Color
 rdbu7_4 =
-    rgb 209 229 240
+    rgb255 209 229 240
 
 
 {-| Provides the RdBu7-5 color.
 -}
 rdbu7_5 : Color
 rdbu7_5 =
-    rgb 103 169 207
+    rgb255 103 169 207
 
 
 {-| Provides the RdBu7-6 color.
 -}
 rdbu7_6 : Color
 rdbu7_6 =
-    rgb 33 102 172
+    rgb255 33 102 172
 
 
 {-| Provides the RdBu8 color scheme.
 -}
 rdbu8 : List Color
 rdbu8 =
-    [ rgb 178 24 43, rgb 214 96 77, rgb 244 165 130, rgb 253 219 199, rgb 209 229 240, rgb 146 197 222, rgb 67 147 195, rgb 33 102 172 ]
+    [ rgb255 178 24 43, rgb255 214 96 77, rgb255 244 165 130, rgb255 253 219 199, rgb255 209 229 240, rgb255 146 197 222, rgb255 67 147 195, rgb255 33 102 172 ]
 
 
 {-| Provides the RdBu8-0 color.
 -}
 rdbu8_0 : Color
 rdbu8_0 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdBu8-1 color.
 -}
 rdbu8_1 : Color
 rdbu8_1 =
-    rgb 214 96 77
+    rgb255 214 96 77
 
 
 {-| Provides the RdBu8-2 color.
 -}
 rdbu8_2 : Color
 rdbu8_2 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdBu8-3 color.
 -}
 rdbu8_3 : Color
 rdbu8_3 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdBu8-4 color.
 -}
 rdbu8_4 : Color
 rdbu8_4 =
-    rgb 209 229 240
+    rgb255 209 229 240
 
 
 {-| Provides the RdBu8-5 color.
 -}
 rdbu8_5 : Color
 rdbu8_5 =
-    rgb 146 197 222
+    rgb255 146 197 222
 
 
 {-| Provides the RdBu8-6 color.
 -}
 rdbu8_6 : Color
 rdbu8_6 =
-    rgb 67 147 195
+    rgb255 67 147 195
 
 
 {-| Provides the RdBu8-7 color.
 -}
 rdbu8_7 : Color
 rdbu8_7 =
-    rgb 33 102 172
+    rgb255 33 102 172
 
 
 {-| Provides the RdBu9 color scheme.
 -}
 rdbu9 : List Color
 rdbu9 =
-    [ rgb 178 24 43, rgb 214 96 77, rgb 244 165 130, rgb 253 219 199, rgb 247 247 247, rgb 209 229 240, rgb 146 197 222, rgb 67 147 195, rgb 33 102 172 ]
+    [ rgb255 178 24 43, rgb255 214 96 77, rgb255 244 165 130, rgb255 253 219 199, rgb255 247 247 247, rgb255 209 229 240, rgb255 146 197 222, rgb255 67 147 195, rgb255 33 102 172 ]
 
 
 {-| Provides the RdBu9-0 color.
 -}
 rdbu9_0 : Color
 rdbu9_0 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdBu9-1 color.
 -}
 rdbu9_1 : Color
 rdbu9_1 =
-    rgb 214 96 77
+    rgb255 214 96 77
 
 
 {-| Provides the RdBu9-2 color.
 -}
 rdbu9_2 : Color
 rdbu9_2 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdBu9-3 color.
 -}
 rdbu9_3 : Color
 rdbu9_3 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdBu9-4 color.
 -}
 rdbu9_4 : Color
 rdbu9_4 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the RdBu9-5 color.
 -}
 rdbu9_5 : Color
 rdbu9_5 =
-    rgb 209 229 240
+    rgb255 209 229 240
 
 
 {-| Provides the RdBu9-6 color.
 -}
 rdbu9_6 : Color
 rdbu9_6 =
-    rgb 146 197 222
+    rgb255 146 197 222
 
 
 {-| Provides the RdBu9-7 color.
 -}
 rdbu9_7 : Color
 rdbu9_7 =
-    rgb 67 147 195
+    rgb255 67 147 195
 
 
 {-| Provides the RdBu9-8 color.
 -}
 rdbu9_8 : Color
 rdbu9_8 =
-    rgb 33 102 172
+    rgb255 33 102 172
 
 
 {-| Provides the RdBu10 color scheme.
 -}
 rdbu10 : List Color
 rdbu10 =
-    [ rgb 103 0 31, rgb 178 24 43, rgb 214 96 77, rgb 244 165 130, rgb 253 219 199, rgb 209 229 240, rgb 146 197 222, rgb 67 147 195, rgb 33 102 172, rgb 5 48 97 ]
+    [ rgb255 103 0 31, rgb255 178 24 43, rgb255 214 96 77, rgb255 244 165 130, rgb255 253 219 199, rgb255 209 229 240, rgb255 146 197 222, rgb255 67 147 195, rgb255 33 102 172, rgb255 5 48 97 ]
 
 
 {-| Provides the RdBu10-0 color.
 -}
 rdbu10_0 : Color
 rdbu10_0 =
-    rgb 103 0 31
+    rgb255 103 0 31
 
 
 {-| Provides the RdBu10-1 color.
 -}
 rdbu10_1 : Color
 rdbu10_1 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdBu10-2 color.
 -}
 rdbu10_2 : Color
 rdbu10_2 =
-    rgb 214 96 77
+    rgb255 214 96 77
 
 
 {-| Provides the RdBu10-3 color.
 -}
 rdbu10_3 : Color
 rdbu10_3 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdBu10-4 color.
 -}
 rdbu10_4 : Color
 rdbu10_4 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdBu10-5 color.
 -}
 rdbu10_5 : Color
 rdbu10_5 =
-    rgb 209 229 240
+    rgb255 209 229 240
 
 
 {-| Provides the RdBu10-6 color.
 -}
 rdbu10_6 : Color
 rdbu10_6 =
-    rgb 146 197 222
+    rgb255 146 197 222
 
 
 {-| Provides the RdBu10-7 color.
 -}
 rdbu10_7 : Color
 rdbu10_7 =
-    rgb 67 147 195
+    rgb255 67 147 195
 
 
 {-| Provides the RdBu10-8 color.
 -}
 rdbu10_8 : Color
 rdbu10_8 =
-    rgb 33 102 172
+    rgb255 33 102 172
 
 
 {-| Provides the RdBu10-9 color.
 -}
 rdbu10_9 : Color
 rdbu10_9 =
-    rgb 5 48 97
+    rgb255 5 48 97
 
 
 {-| Provides the RdBu11 color scheme.
 -}
 rdbu11 : List Color
 rdbu11 =
-    [ rgb 103 0 31, rgb 178 24 43, rgb 214 96 77, rgb 244 165 130, rgb 253 219 199, rgb 247 247 247, rgb 209 229 240, rgb 146 197 222, rgb 67 147 195, rgb 33 102 172, rgb 5 48 97 ]
+    [ rgb255 103 0 31, rgb255 178 24 43, rgb255 214 96 77, rgb255 244 165 130, rgb255 253 219 199, rgb255 247 247 247, rgb255 209 229 240, rgb255 146 197 222, rgb255 67 147 195, rgb255 33 102 172, rgb255 5 48 97 ]
 
 
 {-| Provides the RdBu11-0 color.
 -}
 rdbu11_0 : Color
 rdbu11_0 =
-    rgb 103 0 31
+    rgb255 103 0 31
 
 
 {-| Provides the RdBu11-1 color.
 -}
 rdbu11_1 : Color
 rdbu11_1 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdBu11-2 color.
 -}
 rdbu11_2 : Color
 rdbu11_2 =
-    rgb 214 96 77
+    rgb255 214 96 77
 
 
 {-| Provides the RdBu11-3 color.
 -}
 rdbu11_3 : Color
 rdbu11_3 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdBu11-4 color.
 -}
 rdbu11_4 : Color
 rdbu11_4 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdBu11-5 color.
 -}
 rdbu11_5 : Color
 rdbu11_5 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the RdBu11-6 color.
 -}
 rdbu11_6 : Color
 rdbu11_6 =
-    rgb 209 229 240
+    rgb255 209 229 240
 
 
 {-| Provides the RdBu11-7 color.
 -}
 rdbu11_7 : Color
 rdbu11_7 =
-    rgb 146 197 222
+    rgb255 146 197 222
 
 
 {-| Provides the RdBu11-8 color.
 -}
 rdbu11_8 : Color
 rdbu11_8 =
-    rgb 67 147 195
+    rgb255 67 147 195
 
 
 {-| Provides the RdBu11-9 color.
 -}
 rdbu11_9 : Color
 rdbu11_9 =
-    rgb 33 102 172
+    rgb255 33 102 172
 
 
 {-| Provides the RdBu11-10 color.
 -}
 rdbu11_10 : Color
 rdbu11_10 =
-    rgb 5 48 97
+    rgb255 5 48 97
 
 
 {-| Provides the PiYG3 color scheme.
 -}
 piyg3 : List Color
 piyg3 =
-    [ rgb 233 163 201, rgb 247 247 247, rgb 161 215 106 ]
+    [ rgb255 233 163 201, rgb255 247 247 247, rgb255 161 215 106 ]
 
 
 {-| Provides the PiYG3-0 color.
 -}
 piyg3_0 : Color
 piyg3_0 =
-    rgb 233 163 201
+    rgb255 233 163 201
 
 
 {-| Provides the PiYG3-1 color.
 -}
 piyg3_1 : Color
 piyg3_1 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PiYG3-2 color.
 -}
 piyg3_2 : Color
 piyg3_2 =
-    rgb 161 215 106
+    rgb255 161 215 106
 
 
 {-| Provides the PiYG4 color scheme.
 -}
 piyg4 : List Color
 piyg4 =
-    [ rgb 208 28 139, rgb 241 182 218, rgb 184 225 134, rgb 77 172 38 ]
+    [ rgb255 208 28 139, rgb255 241 182 218, rgb255 184 225 134, rgb255 77 172 38 ]
 
 
 {-| Provides the PiYG4-0 color.
 -}
 piyg4_0 : Color
 piyg4_0 =
-    rgb 208 28 139
+    rgb255 208 28 139
 
 
 {-| Provides the PiYG4-1 color.
 -}
 piyg4_1 : Color
 piyg4_1 =
-    rgb 241 182 218
+    rgb255 241 182 218
 
 
 {-| Provides the PiYG4-2 color.
 -}
 piyg4_2 : Color
 piyg4_2 =
-    rgb 184 225 134
+    rgb255 184 225 134
 
 
 {-| Provides the PiYG4-3 color.
 -}
 piyg4_3 : Color
 piyg4_3 =
-    rgb 77 172 38
+    rgb255 77 172 38
 
 
 {-| Provides the PiYG5 color scheme.
 -}
 piyg5 : List Color
 piyg5 =
-    [ rgb 208 28 139, rgb 241 182 218, rgb 247 247 247, rgb 184 225 134, rgb 77 172 38 ]
+    [ rgb255 208 28 139, rgb255 241 182 218, rgb255 247 247 247, rgb255 184 225 134, rgb255 77 172 38 ]
 
 
 {-| Provides the PiYG5-0 color.
 -}
 piyg5_0 : Color
 piyg5_0 =
-    rgb 208 28 139
+    rgb255 208 28 139
 
 
 {-| Provides the PiYG5-1 color.
 -}
 piyg5_1 : Color
 piyg5_1 =
-    rgb 241 182 218
+    rgb255 241 182 218
 
 
 {-| Provides the PiYG5-2 color.
 -}
 piyg5_2 : Color
 piyg5_2 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PiYG5-3 color.
 -}
 piyg5_3 : Color
 piyg5_3 =
-    rgb 184 225 134
+    rgb255 184 225 134
 
 
 {-| Provides the PiYG5-4 color.
 -}
 piyg5_4 : Color
 piyg5_4 =
-    rgb 77 172 38
+    rgb255 77 172 38
 
 
 {-| Provides the PiYG6 color scheme.
 -}
 piyg6 : List Color
 piyg6 =
-    [ rgb 197 27 125, rgb 233 163 201, rgb 253 224 239, rgb 230 245 208, rgb 161 215 106, rgb 77 146 33 ]
+    [ rgb255 197 27 125, rgb255 233 163 201, rgb255 253 224 239, rgb255 230 245 208, rgb255 161 215 106, rgb255 77 146 33 ]
 
 
 {-| Provides the PiYG6-0 color.
 -}
 piyg6_0 : Color
 piyg6_0 =
-    rgb 197 27 125
+    rgb255 197 27 125
 
 
 {-| Provides the PiYG6-1 color.
 -}
 piyg6_1 : Color
 piyg6_1 =
-    rgb 233 163 201
+    rgb255 233 163 201
 
 
 {-| Provides the PiYG6-2 color.
 -}
 piyg6_2 : Color
 piyg6_2 =
-    rgb 253 224 239
+    rgb255 253 224 239
 
 
 {-| Provides the PiYG6-3 color.
 -}
 piyg6_3 : Color
 piyg6_3 =
-    rgb 230 245 208
+    rgb255 230 245 208
 
 
 {-| Provides the PiYG6-4 color.
 -}
 piyg6_4 : Color
 piyg6_4 =
-    rgb 161 215 106
+    rgb255 161 215 106
 
 
 {-| Provides the PiYG6-5 color.
 -}
 piyg6_5 : Color
 piyg6_5 =
-    rgb 77 146 33
+    rgb255 77 146 33
 
 
 {-| Provides the PiYG7 color scheme.
 -}
 piyg7 : List Color
 piyg7 =
-    [ rgb 197 27 125, rgb 233 163 201, rgb 253 224 239, rgb 247 247 247, rgb 230 245 208, rgb 161 215 106, rgb 77 146 33 ]
+    [ rgb255 197 27 125, rgb255 233 163 201, rgb255 253 224 239, rgb255 247 247 247, rgb255 230 245 208, rgb255 161 215 106, rgb255 77 146 33 ]
 
 
 {-| Provides the PiYG7-0 color.
 -}
 piyg7_0 : Color
 piyg7_0 =
-    rgb 197 27 125
+    rgb255 197 27 125
 
 
 {-| Provides the PiYG7-1 color.
 -}
 piyg7_1 : Color
 piyg7_1 =
-    rgb 233 163 201
+    rgb255 233 163 201
 
 
 {-| Provides the PiYG7-2 color.
 -}
 piyg7_2 : Color
 piyg7_2 =
-    rgb 253 224 239
+    rgb255 253 224 239
 
 
 {-| Provides the PiYG7-3 color.
 -}
 piyg7_3 : Color
 piyg7_3 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PiYG7-4 color.
 -}
 piyg7_4 : Color
 piyg7_4 =
-    rgb 230 245 208
+    rgb255 230 245 208
 
 
 {-| Provides the PiYG7-5 color.
 -}
 piyg7_5 : Color
 piyg7_5 =
-    rgb 161 215 106
+    rgb255 161 215 106
 
 
 {-| Provides the PiYG7-6 color.
 -}
 piyg7_6 : Color
 piyg7_6 =
-    rgb 77 146 33
+    rgb255 77 146 33
 
 
 {-| Provides the PiYG8 color scheme.
 -}
 piyg8 : List Color
 piyg8 =
-    [ rgb 197 27 125, rgb 222 119 174, rgb 241 182 218, rgb 253 224 239, rgb 230 245 208, rgb 184 225 134, rgb 127 188 65, rgb 77 146 33 ]
+    [ rgb255 197 27 125, rgb255 222 119 174, rgb255 241 182 218, rgb255 253 224 239, rgb255 230 245 208, rgb255 184 225 134, rgb255 127 188 65, rgb255 77 146 33 ]
 
 
 {-| Provides the PiYG8-0 color.
 -}
 piyg8_0 : Color
 piyg8_0 =
-    rgb 197 27 125
+    rgb255 197 27 125
 
 
 {-| Provides the PiYG8-1 color.
 -}
 piyg8_1 : Color
 piyg8_1 =
-    rgb 222 119 174
+    rgb255 222 119 174
 
 
 {-| Provides the PiYG8-2 color.
 -}
 piyg8_2 : Color
 piyg8_2 =
-    rgb 241 182 218
+    rgb255 241 182 218
 
 
 {-| Provides the PiYG8-3 color.
 -}
 piyg8_3 : Color
 piyg8_3 =
-    rgb 253 224 239
+    rgb255 253 224 239
 
 
 {-| Provides the PiYG8-4 color.
 -}
 piyg8_4 : Color
 piyg8_4 =
-    rgb 230 245 208
+    rgb255 230 245 208
 
 
 {-| Provides the PiYG8-5 color.
 -}
 piyg8_5 : Color
 piyg8_5 =
-    rgb 184 225 134
+    rgb255 184 225 134
 
 
 {-| Provides the PiYG8-6 color.
 -}
 piyg8_6 : Color
 piyg8_6 =
-    rgb 127 188 65
+    rgb255 127 188 65
 
 
 {-| Provides the PiYG8-7 color.
 -}
 piyg8_7 : Color
 piyg8_7 =
-    rgb 77 146 33
+    rgb255 77 146 33
 
 
 {-| Provides the PiYG9 color scheme.
 -}
 piyg9 : List Color
 piyg9 =
-    [ rgb 197 27 125, rgb 222 119 174, rgb 241 182 218, rgb 253 224 239, rgb 247 247 247, rgb 230 245 208, rgb 184 225 134, rgb 127 188 65, rgb 77 146 33 ]
+    [ rgb255 197 27 125, rgb255 222 119 174, rgb255 241 182 218, rgb255 253 224 239, rgb255 247 247 247, rgb255 230 245 208, rgb255 184 225 134, rgb255 127 188 65, rgb255 77 146 33 ]
 
 
 {-| Provides the PiYG9-0 color.
 -}
 piyg9_0 : Color
 piyg9_0 =
-    rgb 197 27 125
+    rgb255 197 27 125
 
 
 {-| Provides the PiYG9-1 color.
 -}
 piyg9_1 : Color
 piyg9_1 =
-    rgb 222 119 174
+    rgb255 222 119 174
 
 
 {-| Provides the PiYG9-2 color.
 -}
 piyg9_2 : Color
 piyg9_2 =
-    rgb 241 182 218
+    rgb255 241 182 218
 
 
 {-| Provides the PiYG9-3 color.
 -}
 piyg9_3 : Color
 piyg9_3 =
-    rgb 253 224 239
+    rgb255 253 224 239
 
 
 {-| Provides the PiYG9-4 color.
 -}
 piyg9_4 : Color
 piyg9_4 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PiYG9-5 color.
 -}
 piyg9_5 : Color
 piyg9_5 =
-    rgb 230 245 208
+    rgb255 230 245 208
 
 
 {-| Provides the PiYG9-6 color.
 -}
 piyg9_6 : Color
 piyg9_6 =
-    rgb 184 225 134
+    rgb255 184 225 134
 
 
 {-| Provides the PiYG9-7 color.
 -}
 piyg9_7 : Color
 piyg9_7 =
-    rgb 127 188 65
+    rgb255 127 188 65
 
 
 {-| Provides the PiYG9-8 color.
 -}
 piyg9_8 : Color
 piyg9_8 =
-    rgb 77 146 33
+    rgb255 77 146 33
 
 
 {-| Provides the PiYG10 color scheme.
 -}
 piyg10 : List Color
 piyg10 =
-    [ rgb 142 1 82, rgb 197 27 125, rgb 222 119 174, rgb 241 182 218, rgb 253 224 239, rgb 230 245 208, rgb 184 225 134, rgb 127 188 65, rgb 77 146 33, rgb 39 100 25 ]
+    [ rgb255 142 1 82, rgb255 197 27 125, rgb255 222 119 174, rgb255 241 182 218, rgb255 253 224 239, rgb255 230 245 208, rgb255 184 225 134, rgb255 127 188 65, rgb255 77 146 33, rgb255 39 100 25 ]
 
 
 {-| Provides the PiYG10-0 color.
 -}
 piyg10_0 : Color
 piyg10_0 =
-    rgb 142 1 82
+    rgb255 142 1 82
 
 
 {-| Provides the PiYG10-1 color.
 -}
 piyg10_1 : Color
 piyg10_1 =
-    rgb 197 27 125
+    rgb255 197 27 125
 
 
 {-| Provides the PiYG10-2 color.
 -}
 piyg10_2 : Color
 piyg10_2 =
-    rgb 222 119 174
+    rgb255 222 119 174
 
 
 {-| Provides the PiYG10-3 color.
 -}
 piyg10_3 : Color
 piyg10_3 =
-    rgb 241 182 218
+    rgb255 241 182 218
 
 
 {-| Provides the PiYG10-4 color.
 -}
 piyg10_4 : Color
 piyg10_4 =
-    rgb 253 224 239
+    rgb255 253 224 239
 
 
 {-| Provides the PiYG10-5 color.
 -}
 piyg10_5 : Color
 piyg10_5 =
-    rgb 230 245 208
+    rgb255 230 245 208
 
 
 {-| Provides the PiYG10-6 color.
 -}
 piyg10_6 : Color
 piyg10_6 =
-    rgb 184 225 134
+    rgb255 184 225 134
 
 
 {-| Provides the PiYG10-7 color.
 -}
 piyg10_7 : Color
 piyg10_7 =
-    rgb 127 188 65
+    rgb255 127 188 65
 
 
 {-| Provides the PiYG10-8 color.
 -}
 piyg10_8 : Color
 piyg10_8 =
-    rgb 77 146 33
+    rgb255 77 146 33
 
 
 {-| Provides the PiYG10-9 color.
 -}
 piyg10_9 : Color
 piyg10_9 =
-    rgb 39 100 25
+    rgb255 39 100 25
 
 
 {-| Provides the PiYG11 color scheme.
 -}
 piyg11 : List Color
 piyg11 =
-    [ rgb 142 1 82, rgb 197 27 125, rgb 222 119 174, rgb 241 182 218, rgb 253 224 239, rgb 247 247 247, rgb 230 245 208, rgb 184 225 134, rgb 127 188 65, rgb 77 146 33, rgb 39 100 25 ]
+    [ rgb255 142 1 82, rgb255 197 27 125, rgb255 222 119 174, rgb255 241 182 218, rgb255 253 224 239, rgb255 247 247 247, rgb255 230 245 208, rgb255 184 225 134, rgb255 127 188 65, rgb255 77 146 33, rgb255 39 100 25 ]
 
 
 {-| Provides the PiYG11-0 color.
 -}
 piyg11_0 : Color
 piyg11_0 =
-    rgb 142 1 82
+    rgb255 142 1 82
 
 
 {-| Provides the PiYG11-1 color.
 -}
 piyg11_1 : Color
 piyg11_1 =
-    rgb 197 27 125
+    rgb255 197 27 125
 
 
 {-| Provides the PiYG11-2 color.
 -}
 piyg11_2 : Color
 piyg11_2 =
-    rgb 222 119 174
+    rgb255 222 119 174
 
 
 {-| Provides the PiYG11-3 color.
 -}
 piyg11_3 : Color
 piyg11_3 =
-    rgb 241 182 218
+    rgb255 241 182 218
 
 
 {-| Provides the PiYG11-4 color.
 -}
 piyg11_4 : Color
 piyg11_4 =
-    rgb 253 224 239
+    rgb255 253 224 239
 
 
 {-| Provides the PiYG11-5 color.
 -}
 piyg11_5 : Color
 piyg11_5 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PiYG11-6 color.
 -}
 piyg11_6 : Color
 piyg11_6 =
-    rgb 230 245 208
+    rgb255 230 245 208
 
 
 {-| Provides the PiYG11-7 color.
 -}
 piyg11_7 : Color
 piyg11_7 =
-    rgb 184 225 134
+    rgb255 184 225 134
 
 
 {-| Provides the PiYG11-8 color.
 -}
 piyg11_8 : Color
 piyg11_8 =
-    rgb 127 188 65
+    rgb255 127 188 65
 
 
 {-| Provides the PiYG11-9 color.
 -}
 piyg11_9 : Color
 piyg11_9 =
-    rgb 77 146 33
+    rgb255 77 146 33
 
 
 {-| Provides the PiYG11-10 color.
 -}
 piyg11_10 : Color
 piyg11_10 =
-    rgb 39 100 25
+    rgb255 39 100 25
 
 
 {-| Provides the PRGn3 color scheme.
 -}
 prgn3 : List Color
 prgn3 =
-    [ rgb 175 141 195, rgb 247 247 247, rgb 127 191 123 ]
+    [ rgb255 175 141 195, rgb255 247 247 247, rgb255 127 191 123 ]
 
 
 {-| Provides the PRGn3-0 color.
 -}
 prgn3_0 : Color
 prgn3_0 =
-    rgb 175 141 195
+    rgb255 175 141 195
 
 
 {-| Provides the PRGn3-1 color.
 -}
 prgn3_1 : Color
 prgn3_1 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PRGn3-2 color.
 -}
 prgn3_2 : Color
 prgn3_2 =
-    rgb 127 191 123
+    rgb255 127 191 123
 
 
 {-| Provides the PRGn4 color scheme.
 -}
 prgn4 : List Color
 prgn4 =
-    [ rgb 123 50 148, rgb 194 165 207, rgb 166 219 160, rgb 0 136 55 ]
+    [ rgb255 123 50 148, rgb255 194 165 207, rgb255 166 219 160, rgb255 0 136 55 ]
 
 
 {-| Provides the PRGn4-0 color.
 -}
 prgn4_0 : Color
 prgn4_0 =
-    rgb 123 50 148
+    rgb255 123 50 148
 
 
 {-| Provides the PRGn4-1 color.
 -}
 prgn4_1 : Color
 prgn4_1 =
-    rgb 194 165 207
+    rgb255 194 165 207
 
 
 {-| Provides the PRGn4-2 color.
 -}
 prgn4_2 : Color
 prgn4_2 =
-    rgb 166 219 160
+    rgb255 166 219 160
 
 
 {-| Provides the PRGn4-3 color.
 -}
 prgn4_3 : Color
 prgn4_3 =
-    rgb 0 136 55
+    rgb255 0 136 55
 
 
 {-| Provides the PRGn5 color scheme.
 -}
 prgn5 : List Color
 prgn5 =
-    [ rgb 123 50 148, rgb 194 165 207, rgb 247 247 247, rgb 166 219 160, rgb 0 136 55 ]
+    [ rgb255 123 50 148, rgb255 194 165 207, rgb255 247 247 247, rgb255 166 219 160, rgb255 0 136 55 ]
 
 
 {-| Provides the PRGn5-0 color.
 -}
 prgn5_0 : Color
 prgn5_0 =
-    rgb 123 50 148
+    rgb255 123 50 148
 
 
 {-| Provides the PRGn5-1 color.
 -}
 prgn5_1 : Color
 prgn5_1 =
-    rgb 194 165 207
+    rgb255 194 165 207
 
 
 {-| Provides the PRGn5-2 color.
 -}
 prgn5_2 : Color
 prgn5_2 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PRGn5-3 color.
 -}
 prgn5_3 : Color
 prgn5_3 =
-    rgb 166 219 160
+    rgb255 166 219 160
 
 
 {-| Provides the PRGn5-4 color.
 -}
 prgn5_4 : Color
 prgn5_4 =
-    rgb 0 136 55
+    rgb255 0 136 55
 
 
 {-| Provides the PRGn6 color scheme.
 -}
 prgn6 : List Color
 prgn6 =
-    [ rgb 118 42 131, rgb 175 141 195, rgb 231 212 232, rgb 217 240 211, rgb 127 191 123, rgb 27 120 55 ]
+    [ rgb255 118 42 131, rgb255 175 141 195, rgb255 231 212 232, rgb255 217 240 211, rgb255 127 191 123, rgb255 27 120 55 ]
 
 
 {-| Provides the PRGn6-0 color.
 -}
 prgn6_0 : Color
 prgn6_0 =
-    rgb 118 42 131
+    rgb255 118 42 131
 
 
 {-| Provides the PRGn6-1 color.
 -}
 prgn6_1 : Color
 prgn6_1 =
-    rgb 175 141 195
+    rgb255 175 141 195
 
 
 {-| Provides the PRGn6-2 color.
 -}
 prgn6_2 : Color
 prgn6_2 =
-    rgb 231 212 232
+    rgb255 231 212 232
 
 
 {-| Provides the PRGn6-3 color.
 -}
 prgn6_3 : Color
 prgn6_3 =
-    rgb 217 240 211
+    rgb255 217 240 211
 
 
 {-| Provides the PRGn6-4 color.
 -}
 prgn6_4 : Color
 prgn6_4 =
-    rgb 127 191 123
+    rgb255 127 191 123
 
 
 {-| Provides the PRGn6-5 color.
 -}
 prgn6_5 : Color
 prgn6_5 =
-    rgb 27 120 55
+    rgb255 27 120 55
 
 
 {-| Provides the PRGn7 color scheme.
 -}
 prgn7 : List Color
 prgn7 =
-    [ rgb 118 42 131, rgb 175 141 195, rgb 231 212 232, rgb 247 247 247, rgb 217 240 211, rgb 127 191 123, rgb 27 120 55 ]
+    [ rgb255 118 42 131, rgb255 175 141 195, rgb255 231 212 232, rgb255 247 247 247, rgb255 217 240 211, rgb255 127 191 123, rgb255 27 120 55 ]
 
 
 {-| Provides the PRGn7-0 color.
 -}
 prgn7_0 : Color
 prgn7_0 =
-    rgb 118 42 131
+    rgb255 118 42 131
 
 
 {-| Provides the PRGn7-1 color.
 -}
 prgn7_1 : Color
 prgn7_1 =
-    rgb 175 141 195
+    rgb255 175 141 195
 
 
 {-| Provides the PRGn7-2 color.
 -}
 prgn7_2 : Color
 prgn7_2 =
-    rgb 231 212 232
+    rgb255 231 212 232
 
 
 {-| Provides the PRGn7-3 color.
 -}
 prgn7_3 : Color
 prgn7_3 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PRGn7-4 color.
 -}
 prgn7_4 : Color
 prgn7_4 =
-    rgb 217 240 211
+    rgb255 217 240 211
 
 
 {-| Provides the PRGn7-5 color.
 -}
 prgn7_5 : Color
 prgn7_5 =
-    rgb 127 191 123
+    rgb255 127 191 123
 
 
 {-| Provides the PRGn7-6 color.
 -}
 prgn7_6 : Color
 prgn7_6 =
-    rgb 27 120 55
+    rgb255 27 120 55
 
 
 {-| Provides the PRGn8 color scheme.
 -}
 prgn8 : List Color
 prgn8 =
-    [ rgb 118 42 131, rgb 153 112 171, rgb 194 165 207, rgb 231 212 232, rgb 217 240 211, rgb 166 219 160, rgb 90 174 97, rgb 27 120 55 ]
+    [ rgb255 118 42 131, rgb255 153 112 171, rgb255 194 165 207, rgb255 231 212 232, rgb255 217 240 211, rgb255 166 219 160, rgb255 90 174 97, rgb255 27 120 55 ]
 
 
 {-| Provides the PRGn8-0 color.
 -}
 prgn8_0 : Color
 prgn8_0 =
-    rgb 118 42 131
+    rgb255 118 42 131
 
 
 {-| Provides the PRGn8-1 color.
 -}
 prgn8_1 : Color
 prgn8_1 =
-    rgb 153 112 171
+    rgb255 153 112 171
 
 
 {-| Provides the PRGn8-2 color.
 -}
 prgn8_2 : Color
 prgn8_2 =
-    rgb 194 165 207
+    rgb255 194 165 207
 
 
 {-| Provides the PRGn8-3 color.
 -}
 prgn8_3 : Color
 prgn8_3 =
-    rgb 231 212 232
+    rgb255 231 212 232
 
 
 {-| Provides the PRGn8-4 color.
 -}
 prgn8_4 : Color
 prgn8_4 =
-    rgb 217 240 211
+    rgb255 217 240 211
 
 
 {-| Provides the PRGn8-5 color.
 -}
 prgn8_5 : Color
 prgn8_5 =
-    rgb 166 219 160
+    rgb255 166 219 160
 
 
 {-| Provides the PRGn8-6 color.
 -}
 prgn8_6 : Color
 prgn8_6 =
-    rgb 90 174 97
+    rgb255 90 174 97
 
 
 {-| Provides the PRGn8-7 color.
 -}
 prgn8_7 : Color
 prgn8_7 =
-    rgb 27 120 55
+    rgb255 27 120 55
 
 
 {-| Provides the PRGn9 color scheme.
 -}
 prgn9 : List Color
 prgn9 =
-    [ rgb 118 42 131, rgb 153 112 171, rgb 194 165 207, rgb 231 212 232, rgb 247 247 247, rgb 217 240 211, rgb 166 219 160, rgb 90 174 97, rgb 27 120 55 ]
+    [ rgb255 118 42 131, rgb255 153 112 171, rgb255 194 165 207, rgb255 231 212 232, rgb255 247 247 247, rgb255 217 240 211, rgb255 166 219 160, rgb255 90 174 97, rgb255 27 120 55 ]
 
 
 {-| Provides the PRGn9-0 color.
 -}
 prgn9_0 : Color
 prgn9_0 =
-    rgb 118 42 131
+    rgb255 118 42 131
 
 
 {-| Provides the PRGn9-1 color.
 -}
 prgn9_1 : Color
 prgn9_1 =
-    rgb 153 112 171
+    rgb255 153 112 171
 
 
 {-| Provides the PRGn9-2 color.
 -}
 prgn9_2 : Color
 prgn9_2 =
-    rgb 194 165 207
+    rgb255 194 165 207
 
 
 {-| Provides the PRGn9-3 color.
 -}
 prgn9_3 : Color
 prgn9_3 =
-    rgb 231 212 232
+    rgb255 231 212 232
 
 
 {-| Provides the PRGn9-4 color.
 -}
 prgn9_4 : Color
 prgn9_4 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PRGn9-5 color.
 -}
 prgn9_5 : Color
 prgn9_5 =
-    rgb 217 240 211
+    rgb255 217 240 211
 
 
 {-| Provides the PRGn9-6 color.
 -}
 prgn9_6 : Color
 prgn9_6 =
-    rgb 166 219 160
+    rgb255 166 219 160
 
 
 {-| Provides the PRGn9-7 color.
 -}
 prgn9_7 : Color
 prgn9_7 =
-    rgb 90 174 97
+    rgb255 90 174 97
 
 
 {-| Provides the PRGn9-8 color.
 -}
 prgn9_8 : Color
 prgn9_8 =
-    rgb 27 120 55
+    rgb255 27 120 55
 
 
 {-| Provides the PRGn10 color scheme.
 -}
 prgn10 : List Color
 prgn10 =
-    [ rgb 64 0 75, rgb 118 42 131, rgb 153 112 171, rgb 194 165 207, rgb 231 212 232, rgb 217 240 211, rgb 166 219 160, rgb 90 174 97, rgb 27 120 55, rgb 0 68 27 ]
+    [ rgb255 64 0 75, rgb255 118 42 131, rgb255 153 112 171, rgb255 194 165 207, rgb255 231 212 232, rgb255 217 240 211, rgb255 166 219 160, rgb255 90 174 97, rgb255 27 120 55, rgb255 0 68 27 ]
 
 
 {-| Provides the PRGn10-0 color.
 -}
 prgn10_0 : Color
 prgn10_0 =
-    rgb 64 0 75
+    rgb255 64 0 75
 
 
 {-| Provides the PRGn10-1 color.
 -}
 prgn10_1 : Color
 prgn10_1 =
-    rgb 118 42 131
+    rgb255 118 42 131
 
 
 {-| Provides the PRGn10-2 color.
 -}
 prgn10_2 : Color
 prgn10_2 =
-    rgb 153 112 171
+    rgb255 153 112 171
 
 
 {-| Provides the PRGn10-3 color.
 -}
 prgn10_3 : Color
 prgn10_3 =
-    rgb 194 165 207
+    rgb255 194 165 207
 
 
 {-| Provides the PRGn10-4 color.
 -}
 prgn10_4 : Color
 prgn10_4 =
-    rgb 231 212 232
+    rgb255 231 212 232
 
 
 {-| Provides the PRGn10-5 color.
 -}
 prgn10_5 : Color
 prgn10_5 =
-    rgb 217 240 211
+    rgb255 217 240 211
 
 
 {-| Provides the PRGn10-6 color.
 -}
 prgn10_6 : Color
 prgn10_6 =
-    rgb 166 219 160
+    rgb255 166 219 160
 
 
 {-| Provides the PRGn10-7 color.
 -}
 prgn10_7 : Color
 prgn10_7 =
-    rgb 90 174 97
+    rgb255 90 174 97
 
 
 {-| Provides the PRGn10-8 color.
 -}
 prgn10_8 : Color
 prgn10_8 =
-    rgb 27 120 55
+    rgb255 27 120 55
 
 
 {-| Provides the PRGn10-9 color.
 -}
 prgn10_9 : Color
 prgn10_9 =
-    rgb 0 68 27
+    rgb255 0 68 27
 
 
 {-| Provides the PRGn11 color scheme.
 -}
 prgn11 : List Color
 prgn11 =
-    [ rgb 64 0 75, rgb 118 42 131, rgb 153 112 171, rgb 194 165 207, rgb 231 212 232, rgb 247 247 247, rgb 217 240 211, rgb 166 219 160, rgb 90 174 97, rgb 27 120 55, rgb 0 68 27 ]
+    [ rgb255 64 0 75, rgb255 118 42 131, rgb255 153 112 171, rgb255 194 165 207, rgb255 231 212 232, rgb255 247 247 247, rgb255 217 240 211, rgb255 166 219 160, rgb255 90 174 97, rgb255 27 120 55, rgb255 0 68 27 ]
 
 
 {-| Provides the PRGn11-0 color.
 -}
 prgn11_0 : Color
 prgn11_0 =
-    rgb 64 0 75
+    rgb255 64 0 75
 
 
 {-| Provides the PRGn11-1 color.
 -}
 prgn11_1 : Color
 prgn11_1 =
-    rgb 118 42 131
+    rgb255 118 42 131
 
 
 {-| Provides the PRGn11-2 color.
 -}
 prgn11_2 : Color
 prgn11_2 =
-    rgb 153 112 171
+    rgb255 153 112 171
 
 
 {-| Provides the PRGn11-3 color.
 -}
 prgn11_3 : Color
 prgn11_3 =
-    rgb 194 165 207
+    rgb255 194 165 207
 
 
 {-| Provides the PRGn11-4 color.
 -}
 prgn11_4 : Color
 prgn11_4 =
-    rgb 231 212 232
+    rgb255 231 212 232
 
 
 {-| Provides the PRGn11-5 color.
 -}
 prgn11_5 : Color
 prgn11_5 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PRGn11-6 color.
 -}
 prgn11_6 : Color
 prgn11_6 =
-    rgb 217 240 211
+    rgb255 217 240 211
 
 
 {-| Provides the PRGn11-7 color.
 -}
 prgn11_7 : Color
 prgn11_7 =
-    rgb 166 219 160
+    rgb255 166 219 160
 
 
 {-| Provides the PRGn11-8 color.
 -}
 prgn11_8 : Color
 prgn11_8 =
-    rgb 90 174 97
+    rgb255 90 174 97
 
 
 {-| Provides the PRGn11-9 color.
 -}
 prgn11_9 : Color
 prgn11_9 =
-    rgb 27 120 55
+    rgb255 27 120 55
 
 
 {-| Provides the PRGn11-10 color.
 -}
 prgn11_10 : Color
 prgn11_10 =
-    rgb 0 68 27
+    rgb255 0 68 27
 
 
 {-| Provides the RdYlBu3 color scheme.
 -}
 rdylbu3 : List Color
 rdylbu3 =
-    [ rgb 252 141 89, rgb 255 255 191, rgb 145 191 219 ]
+    [ rgb255 252 141 89, rgb255 255 255 191, rgb255 145 191 219 ]
 
 
 {-| Provides the RdYlBu3-0 color.
 -}
 rdylbu3_0 : Color
 rdylbu3_0 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the RdYlBu3-1 color.
 -}
 rdylbu3_1 : Color
 rdylbu3_1 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the RdYlBu3-2 color.
 -}
 rdylbu3_2 : Color
 rdylbu3_2 =
-    rgb 145 191 219
+    rgb255 145 191 219
 
 
 {-| Provides the RdYlBu4 color scheme.
 -}
 rdylbu4 : List Color
 rdylbu4 =
-    [ rgb 215 25 28, rgb 253 174 97, rgb 171 217 233, rgb 44 123 182 ]
+    [ rgb255 215 25 28, rgb255 253 174 97, rgb255 171 217 233, rgb255 44 123 182 ]
 
 
 {-| Provides the RdYlBu4-0 color.
 -}
 rdylbu4_0 : Color
 rdylbu4_0 =
-    rgb 215 25 28
+    rgb255 215 25 28
 
 
 {-| Provides the RdYlBu4-1 color.
 -}
 rdylbu4_1 : Color
 rdylbu4_1 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlBu4-2 color.
 -}
 rdylbu4_2 : Color
 rdylbu4_2 =
-    rgb 171 217 233
+    rgb255 171 217 233
 
 
 {-| Provides the RdYlBu4-3 color.
 -}
 rdylbu4_3 : Color
 rdylbu4_3 =
-    rgb 44 123 182
+    rgb255 44 123 182
 
 
 {-| Provides the RdYlBu5 color scheme.
 -}
 rdylbu5 : List Color
 rdylbu5 =
-    [ rgb 215 25 28, rgb 253 174 97, rgb 255 255 191, rgb 171 217 233, rgb 44 123 182 ]
+    [ rgb255 215 25 28, rgb255 253 174 97, rgb255 255 255 191, rgb255 171 217 233, rgb255 44 123 182 ]
 
 
 {-| Provides the RdYlBu5-0 color.
 -}
 rdylbu5_0 : Color
 rdylbu5_0 =
-    rgb 215 25 28
+    rgb255 215 25 28
 
 
 {-| Provides the RdYlBu5-1 color.
 -}
 rdylbu5_1 : Color
 rdylbu5_1 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlBu5-2 color.
 -}
 rdylbu5_2 : Color
 rdylbu5_2 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the RdYlBu5-3 color.
 -}
 rdylbu5_3 : Color
 rdylbu5_3 =
-    rgb 171 217 233
+    rgb255 171 217 233
 
 
 {-| Provides the RdYlBu5-4 color.
 -}
 rdylbu5_4 : Color
 rdylbu5_4 =
-    rgb 44 123 182
+    rgb255 44 123 182
 
 
 {-| Provides the RdYlBu6 color scheme.
 -}
 rdylbu6 : List Color
 rdylbu6 =
-    [ rgb 215 48 39, rgb 252 141 89, rgb 254 224 144, rgb 224 243 248, rgb 145 191 219, rgb 69 117 180 ]
+    [ rgb255 215 48 39, rgb255 252 141 89, rgb255 254 224 144, rgb255 224 243 248, rgb255 145 191 219, rgb255 69 117 180 ]
 
 
 {-| Provides the RdYlBu6-0 color.
 -}
 rdylbu6_0 : Color
 rdylbu6_0 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlBu6-1 color.
 -}
 rdylbu6_1 : Color
 rdylbu6_1 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the RdYlBu6-2 color.
 -}
 rdylbu6_2 : Color
 rdylbu6_2 =
-    rgb 254 224 144
+    rgb255 254 224 144
 
 
 {-| Provides the RdYlBu6-3 color.
 -}
 rdylbu6_3 : Color
 rdylbu6_3 =
-    rgb 224 243 248
+    rgb255 224 243 248
 
 
 {-| Provides the RdYlBu6-4 color.
 -}
 rdylbu6_4 : Color
 rdylbu6_4 =
-    rgb 145 191 219
+    rgb255 145 191 219
 
 
 {-| Provides the RdYlBu6-5 color.
 -}
 rdylbu6_5 : Color
 rdylbu6_5 =
-    rgb 69 117 180
+    rgb255 69 117 180
 
 
 {-| Provides the RdYlBu7 color scheme.
 -}
 rdylbu7 : List Color
 rdylbu7 =
-    [ rgb 215 48 39, rgb 252 141 89, rgb 254 224 144, rgb 255 255 191, rgb 224 243 248, rgb 145 191 219, rgb 69 117 180 ]
+    [ rgb255 215 48 39, rgb255 252 141 89, rgb255 254 224 144, rgb255 255 255 191, rgb255 224 243 248, rgb255 145 191 219, rgb255 69 117 180 ]
 
 
 {-| Provides the RdYlBu7-0 color.
 -}
 rdylbu7_0 : Color
 rdylbu7_0 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlBu7-1 color.
 -}
 rdylbu7_1 : Color
 rdylbu7_1 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the RdYlBu7-2 color.
 -}
 rdylbu7_2 : Color
 rdylbu7_2 =
-    rgb 254 224 144
+    rgb255 254 224 144
 
 
 {-| Provides the RdYlBu7-3 color.
 -}
 rdylbu7_3 : Color
 rdylbu7_3 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the RdYlBu7-4 color.
 -}
 rdylbu7_4 : Color
 rdylbu7_4 =
-    rgb 224 243 248
+    rgb255 224 243 248
 
 
 {-| Provides the RdYlBu7-5 color.
 -}
 rdylbu7_5 : Color
 rdylbu7_5 =
-    rgb 145 191 219
+    rgb255 145 191 219
 
 
 {-| Provides the RdYlBu7-6 color.
 -}
 rdylbu7_6 : Color
 rdylbu7_6 =
-    rgb 69 117 180
+    rgb255 69 117 180
 
 
 {-| Provides the RdYlBu8 color scheme.
 -}
 rdylbu8 : List Color
 rdylbu8 =
-    [ rgb 215 48 39, rgb 244 109 67, rgb 253 174 97, rgb 254 224 144, rgb 224 243 248, rgb 171 217 233, rgb 116 173 209, rgb 69 117 180 ]
+    [ rgb255 215 48 39, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 144, rgb255 224 243 248, rgb255 171 217 233, rgb255 116 173 209, rgb255 69 117 180 ]
 
 
 {-| Provides the RdYlBu8-0 color.
 -}
 rdylbu8_0 : Color
 rdylbu8_0 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlBu8-1 color.
 -}
 rdylbu8_1 : Color
 rdylbu8_1 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the RdYlBu8-2 color.
 -}
 rdylbu8_2 : Color
 rdylbu8_2 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlBu8-3 color.
 -}
 rdylbu8_3 : Color
 rdylbu8_3 =
-    rgb 254 224 144
+    rgb255 254 224 144
 
 
 {-| Provides the RdYlBu8-4 color.
 -}
 rdylbu8_4 : Color
 rdylbu8_4 =
-    rgb 224 243 248
+    rgb255 224 243 248
 
 
 {-| Provides the RdYlBu8-5 color.
 -}
 rdylbu8_5 : Color
 rdylbu8_5 =
-    rgb 171 217 233
+    rgb255 171 217 233
 
 
 {-| Provides the RdYlBu8-6 color.
 -}
 rdylbu8_6 : Color
 rdylbu8_6 =
-    rgb 116 173 209
+    rgb255 116 173 209
 
 
 {-| Provides the RdYlBu8-7 color.
 -}
 rdylbu8_7 : Color
 rdylbu8_7 =
-    rgb 69 117 180
+    rgb255 69 117 180
 
 
 {-| Provides the RdYlBu9 color scheme.
 -}
 rdylbu9 : List Color
 rdylbu9 =
-    [ rgb 215 48 39, rgb 244 109 67, rgb 253 174 97, rgb 254 224 144, rgb 255 255 191, rgb 224 243 248, rgb 171 217 233, rgb 116 173 209, rgb 69 117 180 ]
+    [ rgb255 215 48 39, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 144, rgb255 255 255 191, rgb255 224 243 248, rgb255 171 217 233, rgb255 116 173 209, rgb255 69 117 180 ]
 
 
 {-| Provides the RdYlBu9-0 color.
 -}
 rdylbu9_0 : Color
 rdylbu9_0 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlBu9-1 color.
 -}
 rdylbu9_1 : Color
 rdylbu9_1 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the RdYlBu9-2 color.
 -}
 rdylbu9_2 : Color
 rdylbu9_2 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlBu9-3 color.
 -}
 rdylbu9_3 : Color
 rdylbu9_3 =
-    rgb 254 224 144
+    rgb255 254 224 144
 
 
 {-| Provides the RdYlBu9-4 color.
 -}
 rdylbu9_4 : Color
 rdylbu9_4 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the RdYlBu9-5 color.
 -}
 rdylbu9_5 : Color
 rdylbu9_5 =
-    rgb 224 243 248
+    rgb255 224 243 248
 
 
 {-| Provides the RdYlBu9-6 color.
 -}
 rdylbu9_6 : Color
 rdylbu9_6 =
-    rgb 171 217 233
+    rgb255 171 217 233
 
 
 {-| Provides the RdYlBu9-7 color.
 -}
 rdylbu9_7 : Color
 rdylbu9_7 =
-    rgb 116 173 209
+    rgb255 116 173 209
 
 
 {-| Provides the RdYlBu9-8 color.
 -}
 rdylbu9_8 : Color
 rdylbu9_8 =
-    rgb 69 117 180
+    rgb255 69 117 180
 
 
 {-| Provides the RdYlBu10 color scheme.
 -}
 rdylbu10 : List Color
 rdylbu10 =
-    [ rgb 165 0 38, rgb 215 48 39, rgb 244 109 67, rgb 253 174 97, rgb 254 224 144, rgb 224 243 248, rgb 171 217 233, rgb 116 173 209, rgb 69 117 180, rgb 49 54 149 ]
+    [ rgb255 165 0 38, rgb255 215 48 39, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 144, rgb255 224 243 248, rgb255 171 217 233, rgb255 116 173 209, rgb255 69 117 180, rgb255 49 54 149 ]
 
 
 {-| Provides the RdYlBu10-0 color.
 -}
 rdylbu10_0 : Color
 rdylbu10_0 =
-    rgb 165 0 38
+    rgb255 165 0 38
 
 
 {-| Provides the RdYlBu10-1 color.
 -}
 rdylbu10_1 : Color
 rdylbu10_1 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlBu10-2 color.
 -}
 rdylbu10_2 : Color
 rdylbu10_2 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the RdYlBu10-3 color.
 -}
 rdylbu10_3 : Color
 rdylbu10_3 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlBu10-4 color.
 -}
 rdylbu10_4 : Color
 rdylbu10_4 =
-    rgb 254 224 144
+    rgb255 254 224 144
 
 
 {-| Provides the RdYlBu10-5 color.
 -}
 rdylbu10_5 : Color
 rdylbu10_5 =
-    rgb 224 243 248
+    rgb255 224 243 248
 
 
 {-| Provides the RdYlBu10-6 color.
 -}
 rdylbu10_6 : Color
 rdylbu10_6 =
-    rgb 171 217 233
+    rgb255 171 217 233
 
 
 {-| Provides the RdYlBu10-7 color.
 -}
 rdylbu10_7 : Color
 rdylbu10_7 =
-    rgb 116 173 209
+    rgb255 116 173 209
 
 
 {-| Provides the RdYlBu10-8 color.
 -}
 rdylbu10_8 : Color
 rdylbu10_8 =
-    rgb 69 117 180
+    rgb255 69 117 180
 
 
 {-| Provides the RdYlBu10-9 color.
 -}
 rdylbu10_9 : Color
 rdylbu10_9 =
-    rgb 49 54 149
+    rgb255 49 54 149
 
 
 {-| Provides the RdYlBu11 color scheme.
 -}
 rdylbu11 : List Color
 rdylbu11 =
-    [ rgb 165 0 38, rgb 215 48 39, rgb 244 109 67, rgb 253 174 97, rgb 254 224 144, rgb 255 255 191, rgb 224 243 248, rgb 171 217 233, rgb 116 173 209, rgb 69 117 180, rgb 49 54 149 ]
+    [ rgb255 165 0 38, rgb255 215 48 39, rgb255 244 109 67, rgb255 253 174 97, rgb255 254 224 144, rgb255 255 255 191, rgb255 224 243 248, rgb255 171 217 233, rgb255 116 173 209, rgb255 69 117 180, rgb255 49 54 149 ]
 
 
 {-| Provides the RdYlBu11-0 color.
 -}
 rdylbu11_0 : Color
 rdylbu11_0 =
-    rgb 165 0 38
+    rgb255 165 0 38
 
 
 {-| Provides the RdYlBu11-1 color.
 -}
 rdylbu11_1 : Color
 rdylbu11_1 =
-    rgb 215 48 39
+    rgb255 215 48 39
 
 
 {-| Provides the RdYlBu11-2 color.
 -}
 rdylbu11_2 : Color
 rdylbu11_2 =
-    rgb 244 109 67
+    rgb255 244 109 67
 
 
 {-| Provides the RdYlBu11-3 color.
 -}
 rdylbu11_3 : Color
 rdylbu11_3 =
-    rgb 253 174 97
+    rgb255 253 174 97
 
 
 {-| Provides the RdYlBu11-4 color.
 -}
 rdylbu11_4 : Color
 rdylbu11_4 =
-    rgb 254 224 144
+    rgb255 254 224 144
 
 
 {-| Provides the RdYlBu11-5 color.
 -}
 rdylbu11_5 : Color
 rdylbu11_5 =
-    rgb 255 255 191
+    rgb255 255 255 191
 
 
 {-| Provides the RdYlBu11-6 color.
 -}
 rdylbu11_6 : Color
 rdylbu11_6 =
-    rgb 224 243 248
+    rgb255 224 243 248
 
 
 {-| Provides the RdYlBu11-7 color.
 -}
 rdylbu11_7 : Color
 rdylbu11_7 =
-    rgb 171 217 233
+    rgb255 171 217 233
 
 
 {-| Provides the RdYlBu11-8 color.
 -}
 rdylbu11_8 : Color
 rdylbu11_8 =
-    rgb 116 173 209
+    rgb255 116 173 209
 
 
 {-| Provides the RdYlBu11-9 color.
 -}
 rdylbu11_9 : Color
 rdylbu11_9 =
-    rgb 69 117 180
+    rgb255 69 117 180
 
 
 {-| Provides the RdYlBu11-10 color.
 -}
 rdylbu11_10 : Color
 rdylbu11_10 =
-    rgb 49 54 149
+    rgb255 49 54 149
 
 
 {-| Provides the BrBG3 color scheme.
 -}
 brbg3 : List Color
 brbg3 =
-    [ rgb 216 179 101, rgb 245 245 245, rgb 90 180 172 ]
+    [ rgb255 216 179 101, rgb255 245 245 245, rgb255 90 180 172 ]
 
 
 {-| Provides the BrBG3-0 color.
 -}
 brbg3_0 : Color
 brbg3_0 =
-    rgb 216 179 101
+    rgb255 216 179 101
 
 
 {-| Provides the BrBG3-1 color.
 -}
 brbg3_1 : Color
 brbg3_1 =
-    rgb 245 245 245
+    rgb255 245 245 245
 
 
 {-| Provides the BrBG3-2 color.
 -}
 brbg3_2 : Color
 brbg3_2 =
-    rgb 90 180 172
+    rgb255 90 180 172
 
 
 {-| Provides the BrBG4 color scheme.
 -}
 brbg4 : List Color
 brbg4 =
-    [ rgb 166 97 26, rgb 223 194 125, rgb 128 205 193, rgb 1 133 113 ]
+    [ rgb255 166 97 26, rgb255 223 194 125, rgb255 128 205 193, rgb255 1 133 113 ]
 
 
 {-| Provides the BrBG4-0 color.
 -}
 brbg4_0 : Color
 brbg4_0 =
-    rgb 166 97 26
+    rgb255 166 97 26
 
 
 {-| Provides the BrBG4-1 color.
 -}
 brbg4_1 : Color
 brbg4_1 =
-    rgb 223 194 125
+    rgb255 223 194 125
 
 
 {-| Provides the BrBG4-2 color.
 -}
 brbg4_2 : Color
 brbg4_2 =
-    rgb 128 205 193
+    rgb255 128 205 193
 
 
 {-| Provides the BrBG4-3 color.
 -}
 brbg4_3 : Color
 brbg4_3 =
-    rgb 1 133 113
+    rgb255 1 133 113
 
 
 {-| Provides the BrBG5 color scheme.
 -}
 brbg5 : List Color
 brbg5 =
-    [ rgb 166 97 26, rgb 223 194 125, rgb 245 245 245, rgb 128 205 193, rgb 1 133 113 ]
+    [ rgb255 166 97 26, rgb255 223 194 125, rgb255 245 245 245, rgb255 128 205 193, rgb255 1 133 113 ]
 
 
 {-| Provides the BrBG5-0 color.
 -}
 brbg5_0 : Color
 brbg5_0 =
-    rgb 166 97 26
+    rgb255 166 97 26
 
 
 {-| Provides the BrBG5-1 color.
 -}
 brbg5_1 : Color
 brbg5_1 =
-    rgb 223 194 125
+    rgb255 223 194 125
 
 
 {-| Provides the BrBG5-2 color.
 -}
 brbg5_2 : Color
 brbg5_2 =
-    rgb 245 245 245
+    rgb255 245 245 245
 
 
 {-| Provides the BrBG5-3 color.
 -}
 brbg5_3 : Color
 brbg5_3 =
-    rgb 128 205 193
+    rgb255 128 205 193
 
 
 {-| Provides the BrBG5-4 color.
 -}
 brbg5_4 : Color
 brbg5_4 =
-    rgb 1 133 113
+    rgb255 1 133 113
 
 
 {-| Provides the BrBG6 color scheme.
 -}
 brbg6 : List Color
 brbg6 =
-    [ rgb 140 81 10, rgb 216 179 101, rgb 246 232 195, rgb 199 234 229, rgb 90 180 172, rgb 1 102 94 ]
+    [ rgb255 140 81 10, rgb255 216 179 101, rgb255 246 232 195, rgb255 199 234 229, rgb255 90 180 172, rgb255 1 102 94 ]
 
 
 {-| Provides the BrBG6-0 color.
 -}
 brbg6_0 : Color
 brbg6_0 =
-    rgb 140 81 10
+    rgb255 140 81 10
 
 
 {-| Provides the BrBG6-1 color.
 -}
 brbg6_1 : Color
 brbg6_1 =
-    rgb 216 179 101
+    rgb255 216 179 101
 
 
 {-| Provides the BrBG6-2 color.
 -}
 brbg6_2 : Color
 brbg6_2 =
-    rgb 246 232 195
+    rgb255 246 232 195
 
 
 {-| Provides the BrBG6-3 color.
 -}
 brbg6_3 : Color
 brbg6_3 =
-    rgb 199 234 229
+    rgb255 199 234 229
 
 
 {-| Provides the BrBG6-4 color.
 -}
 brbg6_4 : Color
 brbg6_4 =
-    rgb 90 180 172
+    rgb255 90 180 172
 
 
 {-| Provides the BrBG6-5 color.
 -}
 brbg6_5 : Color
 brbg6_5 =
-    rgb 1 102 94
+    rgb255 1 102 94
 
 
 {-| Provides the BrBG7 color scheme.
 -}
 brbg7 : List Color
 brbg7 =
-    [ rgb 140 81 10, rgb 216 179 101, rgb 246 232 195, rgb 245 245 245, rgb 199 234 229, rgb 90 180 172, rgb 1 102 94 ]
+    [ rgb255 140 81 10, rgb255 216 179 101, rgb255 246 232 195, rgb255 245 245 245, rgb255 199 234 229, rgb255 90 180 172, rgb255 1 102 94 ]
 
 
 {-| Provides the BrBG7-0 color.
 -}
 brbg7_0 : Color
 brbg7_0 =
-    rgb 140 81 10
+    rgb255 140 81 10
 
 
 {-| Provides the BrBG7-1 color.
 -}
 brbg7_1 : Color
 brbg7_1 =
-    rgb 216 179 101
+    rgb255 216 179 101
 
 
 {-| Provides the BrBG7-2 color.
 -}
 brbg7_2 : Color
 brbg7_2 =
-    rgb 246 232 195
+    rgb255 246 232 195
 
 
 {-| Provides the BrBG7-3 color.
 -}
 brbg7_3 : Color
 brbg7_3 =
-    rgb 245 245 245
+    rgb255 245 245 245
 
 
 {-| Provides the BrBG7-4 color.
 -}
 brbg7_4 : Color
 brbg7_4 =
-    rgb 199 234 229
+    rgb255 199 234 229
 
 
 {-| Provides the BrBG7-5 color.
 -}
 brbg7_5 : Color
 brbg7_5 =
-    rgb 90 180 172
+    rgb255 90 180 172
 
 
 {-| Provides the BrBG7-6 color.
 -}
 brbg7_6 : Color
 brbg7_6 =
-    rgb 1 102 94
+    rgb255 1 102 94
 
 
 {-| Provides the BrBG8 color scheme.
 -}
 brbg8 : List Color
 brbg8 =
-    [ rgb 140 81 10, rgb 191 129 45, rgb 223 194 125, rgb 246 232 195, rgb 199 234 229, rgb 128 205 193, rgb 53 151 143, rgb 1 102 94 ]
+    [ rgb255 140 81 10, rgb255 191 129 45, rgb255 223 194 125, rgb255 246 232 195, rgb255 199 234 229, rgb255 128 205 193, rgb255 53 151 143, rgb255 1 102 94 ]
 
 
 {-| Provides the BrBG8-0 color.
 -}
 brbg8_0 : Color
 brbg8_0 =
-    rgb 140 81 10
+    rgb255 140 81 10
 
 
 {-| Provides the BrBG8-1 color.
 -}
 brbg8_1 : Color
 brbg8_1 =
-    rgb 191 129 45
+    rgb255 191 129 45
 
 
 {-| Provides the BrBG8-2 color.
 -}
 brbg8_2 : Color
 brbg8_2 =
-    rgb 223 194 125
+    rgb255 223 194 125
 
 
 {-| Provides the BrBG8-3 color.
 -}
 brbg8_3 : Color
 brbg8_3 =
-    rgb 246 232 195
+    rgb255 246 232 195
 
 
 {-| Provides the BrBG8-4 color.
 -}
 brbg8_4 : Color
 brbg8_4 =
-    rgb 199 234 229
+    rgb255 199 234 229
 
 
 {-| Provides the BrBG8-5 color.
 -}
 brbg8_5 : Color
 brbg8_5 =
-    rgb 128 205 193
+    rgb255 128 205 193
 
 
 {-| Provides the BrBG8-6 color.
 -}
 brbg8_6 : Color
 brbg8_6 =
-    rgb 53 151 143
+    rgb255 53 151 143
 
 
 {-| Provides the BrBG8-7 color.
 -}
 brbg8_7 : Color
 brbg8_7 =
-    rgb 1 102 94
+    rgb255 1 102 94
 
 
 {-| Provides the BrBG9 color scheme.
 -}
 brbg9 : List Color
 brbg9 =
-    [ rgb 140 81 10, rgb 191 129 45, rgb 223 194 125, rgb 246 232 195, rgb 245 245 245, rgb 199 234 229, rgb 128 205 193, rgb 53 151 143, rgb 1 102 94 ]
+    [ rgb255 140 81 10, rgb255 191 129 45, rgb255 223 194 125, rgb255 246 232 195, rgb255 245 245 245, rgb255 199 234 229, rgb255 128 205 193, rgb255 53 151 143, rgb255 1 102 94 ]
 
 
 {-| Provides the BrBG9-0 color.
 -}
 brbg9_0 : Color
 brbg9_0 =
-    rgb 140 81 10
+    rgb255 140 81 10
 
 
 {-| Provides the BrBG9-1 color.
 -}
 brbg9_1 : Color
 brbg9_1 =
-    rgb 191 129 45
+    rgb255 191 129 45
 
 
 {-| Provides the BrBG9-2 color.
 -}
 brbg9_2 : Color
 brbg9_2 =
-    rgb 223 194 125
+    rgb255 223 194 125
 
 
 {-| Provides the BrBG9-3 color.
 -}
 brbg9_3 : Color
 brbg9_3 =
-    rgb 246 232 195
+    rgb255 246 232 195
 
 
 {-| Provides the BrBG9-4 color.
 -}
 brbg9_4 : Color
 brbg9_4 =
-    rgb 245 245 245
+    rgb255 245 245 245
 
 
 {-| Provides the BrBG9-5 color.
 -}
 brbg9_5 : Color
 brbg9_5 =
-    rgb 199 234 229
+    rgb255 199 234 229
 
 
 {-| Provides the BrBG9-6 color.
 -}
 brbg9_6 : Color
 brbg9_6 =
-    rgb 128 205 193
+    rgb255 128 205 193
 
 
 {-| Provides the BrBG9-7 color.
 -}
 brbg9_7 : Color
 brbg9_7 =
-    rgb 53 151 143
+    rgb255 53 151 143
 
 
 {-| Provides the BrBG9-8 color.
 -}
 brbg9_8 : Color
 brbg9_8 =
-    rgb 1 102 94
+    rgb255 1 102 94
 
 
 {-| Provides the BrBG10 color scheme.
 -}
 brbg10 : List Color
 brbg10 =
-    [ rgb 84 48 5, rgb 140 81 10, rgb 191 129 45, rgb 223 194 125, rgb 246 232 195, rgb 199 234 229, rgb 128 205 193, rgb 53 151 143, rgb 1 102 94, rgb 0 60 48 ]
+    [ rgb255 84 48 5, rgb255 140 81 10, rgb255 191 129 45, rgb255 223 194 125, rgb255 246 232 195, rgb255 199 234 229, rgb255 128 205 193, rgb255 53 151 143, rgb255 1 102 94, rgb255 0 60 48 ]
 
 
 {-| Provides the BrBG10-0 color.
 -}
 brbg10_0 : Color
 brbg10_0 =
-    rgb 84 48 5
+    rgb255 84 48 5
 
 
 {-| Provides the BrBG10-1 color.
 -}
 brbg10_1 : Color
 brbg10_1 =
-    rgb 140 81 10
+    rgb255 140 81 10
 
 
 {-| Provides the BrBG10-2 color.
 -}
 brbg10_2 : Color
 brbg10_2 =
-    rgb 191 129 45
+    rgb255 191 129 45
 
 
 {-| Provides the BrBG10-3 color.
 -}
 brbg10_3 : Color
 brbg10_3 =
-    rgb 223 194 125
+    rgb255 223 194 125
 
 
 {-| Provides the BrBG10-4 color.
 -}
 brbg10_4 : Color
 brbg10_4 =
-    rgb 246 232 195
+    rgb255 246 232 195
 
 
 {-| Provides the BrBG10-5 color.
 -}
 brbg10_5 : Color
 brbg10_5 =
-    rgb 199 234 229
+    rgb255 199 234 229
 
 
 {-| Provides the BrBG10-6 color.
 -}
 brbg10_6 : Color
 brbg10_6 =
-    rgb 128 205 193
+    rgb255 128 205 193
 
 
 {-| Provides the BrBG10-7 color.
 -}
 brbg10_7 : Color
 brbg10_7 =
-    rgb 53 151 143
+    rgb255 53 151 143
 
 
 {-| Provides the BrBG10-8 color.
 -}
 brbg10_8 : Color
 brbg10_8 =
-    rgb 1 102 94
+    rgb255 1 102 94
 
 
 {-| Provides the BrBG10-9 color.
 -}
 brbg10_9 : Color
 brbg10_9 =
-    rgb 0 60 48
+    rgb255 0 60 48
 
 
 {-| Provides the BrBG11 color scheme.
 -}
 brbg11 : List Color
 brbg11 =
-    [ rgb 84 48 5, rgb 140 81 10, rgb 191 129 45, rgb 223 194 125, rgb 246 232 195, rgb 245 245 245, rgb 199 234 229, rgb 128 205 193, rgb 53 151 143, rgb 1 102 94, rgb 0 60 48 ]
+    [ rgb255 84 48 5, rgb255 140 81 10, rgb255 191 129 45, rgb255 223 194 125, rgb255 246 232 195, rgb255 245 245 245, rgb255 199 234 229, rgb255 128 205 193, rgb255 53 151 143, rgb255 1 102 94, rgb255 0 60 48 ]
 
 
 {-| Provides the BrBG11-0 color.
 -}
 brbg11_0 : Color
 brbg11_0 =
-    rgb 84 48 5
+    rgb255 84 48 5
 
 
 {-| Provides the BrBG11-1 color.
 -}
 brbg11_1 : Color
 brbg11_1 =
-    rgb 140 81 10
+    rgb255 140 81 10
 
 
 {-| Provides the BrBG11-2 color.
 -}
 brbg11_2 : Color
 brbg11_2 =
-    rgb 191 129 45
+    rgb255 191 129 45
 
 
 {-| Provides the BrBG11-3 color.
 -}
 brbg11_3 : Color
 brbg11_3 =
-    rgb 223 194 125
+    rgb255 223 194 125
 
 
 {-| Provides the BrBG11-4 color.
 -}
 brbg11_4 : Color
 brbg11_4 =
-    rgb 246 232 195
+    rgb255 246 232 195
 
 
 {-| Provides the BrBG11-5 color.
 -}
 brbg11_5 : Color
 brbg11_5 =
-    rgb 245 245 245
+    rgb255 245 245 245
 
 
 {-| Provides the BrBG11-6 color.
 -}
 brbg11_6 : Color
 brbg11_6 =
-    rgb 199 234 229
+    rgb255 199 234 229
 
 
 {-| Provides the BrBG11-7 color.
 -}
 brbg11_7 : Color
 brbg11_7 =
-    rgb 128 205 193
+    rgb255 128 205 193
 
 
 {-| Provides the BrBG11-8 color.
 -}
 brbg11_8 : Color
 brbg11_8 =
-    rgb 53 151 143
+    rgb255 53 151 143
 
 
 {-| Provides the BrBG11-9 color.
 -}
 brbg11_9 : Color
 brbg11_9 =
-    rgb 1 102 94
+    rgb255 1 102 94
 
 
 {-| Provides the BrBG11-10 color.
 -}
 brbg11_10 : Color
 brbg11_10 =
-    rgb 0 60 48
+    rgb255 0 60 48
 
 
 {-| Provides the RdGy3 color scheme.
 -}
 rdgy3 : List Color
 rdgy3 =
-    [ rgb 239 138 98, rgb 255 255 255, rgb 153 153 153 ]
+    [ rgb255 239 138 98, rgb255 255 255 255, rgb255 153 153 153 ]
 
 
 {-| Provides the RdGy3-0 color.
 -}
 rdgy3_0 : Color
 rdgy3_0 =
-    rgb 239 138 98
+    rgb255 239 138 98
 
 
 {-| Provides the RdGy3-1 color.
 -}
 rdgy3_1 : Color
 rdgy3_1 =
-    rgb 255 255 255
+    rgb255 255 255 255
 
 
 {-| Provides the RdGy3-2 color.
 -}
 rdgy3_2 : Color
 rdgy3_2 =
-    rgb 153 153 153
+    rgb255 153 153 153
 
 
 {-| Provides the RdGy4 color scheme.
 -}
 rdgy4 : List Color
 rdgy4 =
-    [ rgb 202 0 32, rgb 244 165 130, rgb 186 186 186, rgb 64 64 64 ]
+    [ rgb255 202 0 32, rgb255 244 165 130, rgb255 186 186 186, rgb255 64 64 64 ]
 
 
 {-| Provides the RdGy4-0 color.
 -}
 rdgy4_0 : Color
 rdgy4_0 =
-    rgb 202 0 32
+    rgb255 202 0 32
 
 
 {-| Provides the RdGy4-1 color.
 -}
 rdgy4_1 : Color
 rdgy4_1 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdGy4-2 color.
 -}
 rdgy4_2 : Color
 rdgy4_2 =
-    rgb 186 186 186
+    rgb255 186 186 186
 
 
 {-| Provides the RdGy4-3 color.
 -}
 rdgy4_3 : Color
 rdgy4_3 =
-    rgb 64 64 64
+    rgb255 64 64 64
 
 
 {-| Provides the RdGy5 color scheme.
 -}
 rdgy5 : List Color
 rdgy5 =
-    [ rgb 202 0 32, rgb 244 165 130, rgb 255 255 255, rgb 186 186 186, rgb 64 64 64 ]
+    [ rgb255 202 0 32, rgb255 244 165 130, rgb255 255 255 255, rgb255 186 186 186, rgb255 64 64 64 ]
 
 
 {-| Provides the RdGy5-0 color.
 -}
 rdgy5_0 : Color
 rdgy5_0 =
-    rgb 202 0 32
+    rgb255 202 0 32
 
 
 {-| Provides the RdGy5-1 color.
 -}
 rdgy5_1 : Color
 rdgy5_1 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdGy5-2 color.
 -}
 rdgy5_2 : Color
 rdgy5_2 =
-    rgb 255 255 255
+    rgb255 255 255 255
 
 
 {-| Provides the RdGy5-3 color.
 -}
 rdgy5_3 : Color
 rdgy5_3 =
-    rgb 186 186 186
+    rgb255 186 186 186
 
 
 {-| Provides the RdGy5-4 color.
 -}
 rdgy5_4 : Color
 rdgy5_4 =
-    rgb 64 64 64
+    rgb255 64 64 64
 
 
 {-| Provides the RdGy6 color scheme.
 -}
 rdgy6 : List Color
 rdgy6 =
-    [ rgb 178 24 43, rgb 239 138 98, rgb 253 219 199, rgb 224 224 224, rgb 153 153 153, rgb 77 77 77 ]
+    [ rgb255 178 24 43, rgb255 239 138 98, rgb255 253 219 199, rgb255 224 224 224, rgb255 153 153 153, rgb255 77 77 77 ]
 
 
 {-| Provides the RdGy6-0 color.
 -}
 rdgy6_0 : Color
 rdgy6_0 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdGy6-1 color.
 -}
 rdgy6_1 : Color
 rdgy6_1 =
-    rgb 239 138 98
+    rgb255 239 138 98
 
 
 {-| Provides the RdGy6-2 color.
 -}
 rdgy6_2 : Color
 rdgy6_2 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdGy6-3 color.
 -}
 rdgy6_3 : Color
 rdgy6_3 =
-    rgb 224 224 224
+    rgb255 224 224 224
 
 
 {-| Provides the RdGy6-4 color.
 -}
 rdgy6_4 : Color
 rdgy6_4 =
-    rgb 153 153 153
+    rgb255 153 153 153
 
 
 {-| Provides the RdGy6-5 color.
 -}
 rdgy6_5 : Color
 rdgy6_5 =
-    rgb 77 77 77
+    rgb255 77 77 77
 
 
 {-| Provides the RdGy7 color scheme.
 -}
 rdgy7 : List Color
 rdgy7 =
-    [ rgb 178 24 43, rgb 239 138 98, rgb 253 219 199, rgb 255 255 255, rgb 224 224 224, rgb 153 153 153, rgb 77 77 77 ]
+    [ rgb255 178 24 43, rgb255 239 138 98, rgb255 253 219 199, rgb255 255 255 255, rgb255 224 224 224, rgb255 153 153 153, rgb255 77 77 77 ]
 
 
 {-| Provides the RdGy7-0 color.
 -}
 rdgy7_0 : Color
 rdgy7_0 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdGy7-1 color.
 -}
 rdgy7_1 : Color
 rdgy7_1 =
-    rgb 239 138 98
+    rgb255 239 138 98
 
 
 {-| Provides the RdGy7-2 color.
 -}
 rdgy7_2 : Color
 rdgy7_2 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdGy7-3 color.
 -}
 rdgy7_3 : Color
 rdgy7_3 =
-    rgb 255 255 255
+    rgb255 255 255 255
 
 
 {-| Provides the RdGy7-4 color.
 -}
 rdgy7_4 : Color
 rdgy7_4 =
-    rgb 224 224 224
+    rgb255 224 224 224
 
 
 {-| Provides the RdGy7-5 color.
 -}
 rdgy7_5 : Color
 rdgy7_5 =
-    rgb 153 153 153
+    rgb255 153 153 153
 
 
 {-| Provides the RdGy7-6 color.
 -}
 rdgy7_6 : Color
 rdgy7_6 =
-    rgb 77 77 77
+    rgb255 77 77 77
 
 
 {-| Provides the RdGy8 color scheme.
 -}
 rdgy8 : List Color
 rdgy8 =
-    [ rgb 178 24 43, rgb 214 96 77, rgb 244 165 130, rgb 253 219 199, rgb 224 224 224, rgb 186 186 186, rgb 135 135 135, rgb 77 77 77 ]
+    [ rgb255 178 24 43, rgb255 214 96 77, rgb255 244 165 130, rgb255 253 219 199, rgb255 224 224 224, rgb255 186 186 186, rgb255 135 135 135, rgb255 77 77 77 ]
 
 
 {-| Provides the RdGy8-0 color.
 -}
 rdgy8_0 : Color
 rdgy8_0 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdGy8-1 color.
 -}
 rdgy8_1 : Color
 rdgy8_1 =
-    rgb 214 96 77
+    rgb255 214 96 77
 
 
 {-| Provides the RdGy8-2 color.
 -}
 rdgy8_2 : Color
 rdgy8_2 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdGy8-3 color.
 -}
 rdgy8_3 : Color
 rdgy8_3 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdGy8-4 color.
 -}
 rdgy8_4 : Color
 rdgy8_4 =
-    rgb 224 224 224
+    rgb255 224 224 224
 
 
 {-| Provides the RdGy8-5 color.
 -}
 rdgy8_5 : Color
 rdgy8_5 =
-    rgb 186 186 186
+    rgb255 186 186 186
 
 
 {-| Provides the RdGy8-6 color.
 -}
 rdgy8_6 : Color
 rdgy8_6 =
-    rgb 135 135 135
+    rgb255 135 135 135
 
 
 {-| Provides the RdGy8-7 color.
 -}
 rdgy8_7 : Color
 rdgy8_7 =
-    rgb 77 77 77
+    rgb255 77 77 77
 
 
 {-| Provides the RdGy9 color scheme.
 -}
 rdgy9 : List Color
 rdgy9 =
-    [ rgb 178 24 43, rgb 214 96 77, rgb 244 165 130, rgb 253 219 199, rgb 255 255 255, rgb 224 224 224, rgb 186 186 186, rgb 135 135 135, rgb 77 77 77 ]
+    [ rgb255 178 24 43, rgb255 214 96 77, rgb255 244 165 130, rgb255 253 219 199, rgb255 255 255 255, rgb255 224 224 224, rgb255 186 186 186, rgb255 135 135 135, rgb255 77 77 77 ]
 
 
 {-| Provides the RdGy9-0 color.
 -}
 rdgy9_0 : Color
 rdgy9_0 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdGy9-1 color.
 -}
 rdgy9_1 : Color
 rdgy9_1 =
-    rgb 214 96 77
+    rgb255 214 96 77
 
 
 {-| Provides the RdGy9-2 color.
 -}
 rdgy9_2 : Color
 rdgy9_2 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdGy9-3 color.
 -}
 rdgy9_3 : Color
 rdgy9_3 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdGy9-4 color.
 -}
 rdgy9_4 : Color
 rdgy9_4 =
-    rgb 255 255 255
+    rgb255 255 255 255
 
 
 {-| Provides the RdGy9-5 color.
 -}
 rdgy9_5 : Color
 rdgy9_5 =
-    rgb 224 224 224
+    rgb255 224 224 224
 
 
 {-| Provides the RdGy9-6 color.
 -}
 rdgy9_6 : Color
 rdgy9_6 =
-    rgb 186 186 186
+    rgb255 186 186 186
 
 
 {-| Provides the RdGy9-7 color.
 -}
 rdgy9_7 : Color
 rdgy9_7 =
-    rgb 135 135 135
+    rgb255 135 135 135
 
 
 {-| Provides the RdGy9-8 color.
 -}
 rdgy9_8 : Color
 rdgy9_8 =
-    rgb 77 77 77
+    rgb255 77 77 77
 
 
 {-| Provides the RdGy10 color scheme.
 -}
 rdgy10 : List Color
 rdgy10 =
-    [ rgb 103 0 31, rgb 178 24 43, rgb 214 96 77, rgb 244 165 130, rgb 253 219 199, rgb 224 224 224, rgb 186 186 186, rgb 135 135 135, rgb 77 77 77, rgb 26 26 26 ]
+    [ rgb255 103 0 31, rgb255 178 24 43, rgb255 214 96 77, rgb255 244 165 130, rgb255 253 219 199, rgb255 224 224 224, rgb255 186 186 186, rgb255 135 135 135, rgb255 77 77 77, rgb255 26 26 26 ]
 
 
 {-| Provides the RdGy10-0 color.
 -}
 rdgy10_0 : Color
 rdgy10_0 =
-    rgb 103 0 31
+    rgb255 103 0 31
 
 
 {-| Provides the RdGy10-1 color.
 -}
 rdgy10_1 : Color
 rdgy10_1 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdGy10-2 color.
 -}
 rdgy10_2 : Color
 rdgy10_2 =
-    rgb 214 96 77
+    rgb255 214 96 77
 
 
 {-| Provides the RdGy10-3 color.
 -}
 rdgy10_3 : Color
 rdgy10_3 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdGy10-4 color.
 -}
 rdgy10_4 : Color
 rdgy10_4 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdGy10-5 color.
 -}
 rdgy10_5 : Color
 rdgy10_5 =
-    rgb 224 224 224
+    rgb255 224 224 224
 
 
 {-| Provides the RdGy10-6 color.
 -}
 rdgy10_6 : Color
 rdgy10_6 =
-    rgb 186 186 186
+    rgb255 186 186 186
 
 
 {-| Provides the RdGy10-7 color.
 -}
 rdgy10_7 : Color
 rdgy10_7 =
-    rgb 135 135 135
+    rgb255 135 135 135
 
 
 {-| Provides the RdGy10-8 color.
 -}
 rdgy10_8 : Color
 rdgy10_8 =
-    rgb 77 77 77
+    rgb255 77 77 77
 
 
 {-| Provides the RdGy10-9 color.
 -}
 rdgy10_9 : Color
 rdgy10_9 =
-    rgb 26 26 26
+    rgb255 26 26 26
 
 
 {-| Provides the RdGy11 color scheme.
 -}
 rdgy11 : List Color
 rdgy11 =
-    [ rgb 103 0 31, rgb 178 24 43, rgb 214 96 77, rgb 244 165 130, rgb 253 219 199, rgb 255 255 255, rgb 224 224 224, rgb 186 186 186, rgb 135 135 135, rgb 77 77 77, rgb 26 26 26 ]
+    [ rgb255 103 0 31, rgb255 178 24 43, rgb255 214 96 77, rgb255 244 165 130, rgb255 253 219 199, rgb255 255 255 255, rgb255 224 224 224, rgb255 186 186 186, rgb255 135 135 135, rgb255 77 77 77, rgb255 26 26 26 ]
 
 
 {-| Provides the RdGy11-0 color.
 -}
 rdgy11_0 : Color
 rdgy11_0 =
-    rgb 103 0 31
+    rgb255 103 0 31
 
 
 {-| Provides the RdGy11-1 color.
 -}
 rdgy11_1 : Color
 rdgy11_1 =
-    rgb 178 24 43
+    rgb255 178 24 43
 
 
 {-| Provides the RdGy11-2 color.
 -}
 rdgy11_2 : Color
 rdgy11_2 =
-    rgb 214 96 77
+    rgb255 214 96 77
 
 
 {-| Provides the RdGy11-3 color.
 -}
 rdgy11_3 : Color
 rdgy11_3 =
-    rgb 244 165 130
+    rgb255 244 165 130
 
 
 {-| Provides the RdGy11-4 color.
 -}
 rdgy11_4 : Color
 rdgy11_4 =
-    rgb 253 219 199
+    rgb255 253 219 199
 
 
 {-| Provides the RdGy11-5 color.
 -}
 rdgy11_5 : Color
 rdgy11_5 =
-    rgb 255 255 255
+    rgb255 255 255 255
 
 
 {-| Provides the RdGy11-6 color.
 -}
 rdgy11_6 : Color
 rdgy11_6 =
-    rgb 224 224 224
+    rgb255 224 224 224
 
 
 {-| Provides the RdGy11-7 color.
 -}
 rdgy11_7 : Color
 rdgy11_7 =
-    rgb 186 186 186
+    rgb255 186 186 186
 
 
 {-| Provides the RdGy11-8 color.
 -}
 rdgy11_8 : Color
 rdgy11_8 =
-    rgb 135 135 135
+    rgb255 135 135 135
 
 
 {-| Provides the RdGy11-9 color.
 -}
 rdgy11_9 : Color
 rdgy11_9 =
-    rgb 77 77 77
+    rgb255 77 77 77
 
 
 {-| Provides the RdGy11-10 color.
 -}
 rdgy11_10 : Color
 rdgy11_10 =
-    rgb 26 26 26
+    rgb255 26 26 26
 
 
 {-| Provides the PuOr3 color scheme.
 -}
 puor3 : List Color
 puor3 =
-    [ rgb 241 163 64, rgb 247 247 247, rgb 153 142 195 ]
+    [ rgb255 241 163 64, rgb255 247 247 247, rgb255 153 142 195 ]
 
 
 {-| Provides the PuOr3-0 color.
 -}
 puor3_0 : Color
 puor3_0 =
-    rgb 241 163 64
+    rgb255 241 163 64
 
 
 {-| Provides the PuOr3-1 color.
 -}
 puor3_1 : Color
 puor3_1 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PuOr3-2 color.
 -}
 puor3_2 : Color
 puor3_2 =
-    rgb 153 142 195
+    rgb255 153 142 195
 
 
 {-| Provides the PuOr4 color scheme.
 -}
 puor4 : List Color
 puor4 =
-    [ rgb 230 97 1, rgb 253 184 99, rgb 178 171 210, rgb 94 60 153 ]
+    [ rgb255 230 97 1, rgb255 253 184 99, rgb255 178 171 210, rgb255 94 60 153 ]
 
 
 {-| Provides the PuOr4-0 color.
 -}
 puor4_0 : Color
 puor4_0 =
-    rgb 230 97 1
+    rgb255 230 97 1
 
 
 {-| Provides the PuOr4-1 color.
 -}
 puor4_1 : Color
 puor4_1 =
-    rgb 253 184 99
+    rgb255 253 184 99
 
 
 {-| Provides the PuOr4-2 color.
 -}
 puor4_2 : Color
 puor4_2 =
-    rgb 178 171 210
+    rgb255 178 171 210
 
 
 {-| Provides the PuOr4-3 color.
 -}
 puor4_3 : Color
 puor4_3 =
-    rgb 94 60 153
+    rgb255 94 60 153
 
 
 {-| Provides the PuOr5 color scheme.
 -}
 puor5 : List Color
 puor5 =
-    [ rgb 230 97 1, rgb 253 184 99, rgb 247 247 247, rgb 178 171 210, rgb 94 60 153 ]
+    [ rgb255 230 97 1, rgb255 253 184 99, rgb255 247 247 247, rgb255 178 171 210, rgb255 94 60 153 ]
 
 
 {-| Provides the PuOr5-0 color.
 -}
 puor5_0 : Color
 puor5_0 =
-    rgb 230 97 1
+    rgb255 230 97 1
 
 
 {-| Provides the PuOr5-1 color.
 -}
 puor5_1 : Color
 puor5_1 =
-    rgb 253 184 99
+    rgb255 253 184 99
 
 
 {-| Provides the PuOr5-2 color.
 -}
 puor5_2 : Color
 puor5_2 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PuOr5-3 color.
 -}
 puor5_3 : Color
 puor5_3 =
-    rgb 178 171 210
+    rgb255 178 171 210
 
 
 {-| Provides the PuOr5-4 color.
 -}
 puor5_4 : Color
 puor5_4 =
-    rgb 94 60 153
+    rgb255 94 60 153
 
 
 {-| Provides the PuOr6 color scheme.
 -}
 puor6 : List Color
 puor6 =
-    [ rgb 179 88 6, rgb 241 163 64, rgb 254 224 182, rgb 216 218 235, rgb 153 142 195, rgb 84 39 136 ]
+    [ rgb255 179 88 6, rgb255 241 163 64, rgb255 254 224 182, rgb255 216 218 235, rgb255 153 142 195, rgb255 84 39 136 ]
 
 
 {-| Provides the PuOr6-0 color.
 -}
 puor6_0 : Color
 puor6_0 =
-    rgb 179 88 6
+    rgb255 179 88 6
 
 
 {-| Provides the PuOr6-1 color.
 -}
 puor6_1 : Color
 puor6_1 =
-    rgb 241 163 64
+    rgb255 241 163 64
 
 
 {-| Provides the PuOr6-2 color.
 -}
 puor6_2 : Color
 puor6_2 =
-    rgb 254 224 182
+    rgb255 254 224 182
 
 
 {-| Provides the PuOr6-3 color.
 -}
 puor6_3 : Color
 puor6_3 =
-    rgb 216 218 235
+    rgb255 216 218 235
 
 
 {-| Provides the PuOr6-4 color.
 -}
 puor6_4 : Color
 puor6_4 =
-    rgb 153 142 195
+    rgb255 153 142 195
 
 
 {-| Provides the PuOr6-5 color.
 -}
 puor6_5 : Color
 puor6_5 =
-    rgb 84 39 136
+    rgb255 84 39 136
 
 
 {-| Provides the PuOr7 color scheme.
 -}
 puor7 : List Color
 puor7 =
-    [ rgb 179 88 6, rgb 241 163 64, rgb 254 224 182, rgb 247 247 247, rgb 216 218 235, rgb 153 142 195, rgb 84 39 136 ]
+    [ rgb255 179 88 6, rgb255 241 163 64, rgb255 254 224 182, rgb255 247 247 247, rgb255 216 218 235, rgb255 153 142 195, rgb255 84 39 136 ]
 
 
 {-| Provides the PuOr7-0 color.
 -}
 puor7_0 : Color
 puor7_0 =
-    rgb 179 88 6
+    rgb255 179 88 6
 
 
 {-| Provides the PuOr7-1 color.
 -}
 puor7_1 : Color
 puor7_1 =
-    rgb 241 163 64
+    rgb255 241 163 64
 
 
 {-| Provides the PuOr7-2 color.
 -}
 puor7_2 : Color
 puor7_2 =
-    rgb 254 224 182
+    rgb255 254 224 182
 
 
 {-| Provides the PuOr7-3 color.
 -}
 puor7_3 : Color
 puor7_3 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PuOr7-4 color.
 -}
 puor7_4 : Color
 puor7_4 =
-    rgb 216 218 235
+    rgb255 216 218 235
 
 
 {-| Provides the PuOr7-5 color.
 -}
 puor7_5 : Color
 puor7_5 =
-    rgb 153 142 195
+    rgb255 153 142 195
 
 
 {-| Provides the PuOr7-6 color.
 -}
 puor7_6 : Color
 puor7_6 =
-    rgb 84 39 136
+    rgb255 84 39 136
 
 
 {-| Provides the PuOr8 color scheme.
 -}
 puor8 : List Color
 puor8 =
-    [ rgb 179 88 6, rgb 224 130 20, rgb 253 184 99, rgb 254 224 182, rgb 216 218 235, rgb 178 171 210, rgb 128 115 172, rgb 84 39 136 ]
+    [ rgb255 179 88 6, rgb255 224 130 20, rgb255 253 184 99, rgb255 254 224 182, rgb255 216 218 235, rgb255 178 171 210, rgb255 128 115 172, rgb255 84 39 136 ]
 
 
 {-| Provides the PuOr8-0 color.
 -}
 puor8_0 : Color
 puor8_0 =
-    rgb 179 88 6
+    rgb255 179 88 6
 
 
 {-| Provides the PuOr8-1 color.
 -}
 puor8_1 : Color
 puor8_1 =
-    rgb 224 130 20
+    rgb255 224 130 20
 
 
 {-| Provides the PuOr8-2 color.
 -}
 puor8_2 : Color
 puor8_2 =
-    rgb 253 184 99
+    rgb255 253 184 99
 
 
 {-| Provides the PuOr8-3 color.
 -}
 puor8_3 : Color
 puor8_3 =
-    rgb 254 224 182
+    rgb255 254 224 182
 
 
 {-| Provides the PuOr8-4 color.
 -}
 puor8_4 : Color
 puor8_4 =
-    rgb 216 218 235
+    rgb255 216 218 235
 
 
 {-| Provides the PuOr8-5 color.
 -}
 puor8_5 : Color
 puor8_5 =
-    rgb 178 171 210
+    rgb255 178 171 210
 
 
 {-| Provides the PuOr8-6 color.
 -}
 puor8_6 : Color
 puor8_6 =
-    rgb 128 115 172
+    rgb255 128 115 172
 
 
 {-| Provides the PuOr8-7 color.
 -}
 puor8_7 : Color
 puor8_7 =
-    rgb 84 39 136
+    rgb255 84 39 136
 
 
 {-| Provides the PuOr9 color scheme.
 -}
 puor9 : List Color
 puor9 =
-    [ rgb 179 88 6, rgb 224 130 20, rgb 253 184 99, rgb 254 224 182, rgb 247 247 247, rgb 216 218 235, rgb 178 171 210, rgb 128 115 172, rgb 84 39 136 ]
+    [ rgb255 179 88 6, rgb255 224 130 20, rgb255 253 184 99, rgb255 254 224 182, rgb255 247 247 247, rgb255 216 218 235, rgb255 178 171 210, rgb255 128 115 172, rgb255 84 39 136 ]
 
 
 {-| Provides the PuOr9-0 color.
 -}
 puor9_0 : Color
 puor9_0 =
-    rgb 179 88 6
+    rgb255 179 88 6
 
 
 {-| Provides the PuOr9-1 color.
 -}
 puor9_1 : Color
 puor9_1 =
-    rgb 224 130 20
+    rgb255 224 130 20
 
 
 {-| Provides the PuOr9-2 color.
 -}
 puor9_2 : Color
 puor9_2 =
-    rgb 253 184 99
+    rgb255 253 184 99
 
 
 {-| Provides the PuOr9-3 color.
 -}
 puor9_3 : Color
 puor9_3 =
-    rgb 254 224 182
+    rgb255 254 224 182
 
 
 {-| Provides the PuOr9-4 color.
 -}
 puor9_4 : Color
 puor9_4 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PuOr9-5 color.
 -}
 puor9_5 : Color
 puor9_5 =
-    rgb 216 218 235
+    rgb255 216 218 235
 
 
 {-| Provides the PuOr9-6 color.
 -}
 puor9_6 : Color
 puor9_6 =
-    rgb 178 171 210
+    rgb255 178 171 210
 
 
 {-| Provides the PuOr9-7 color.
 -}
 puor9_7 : Color
 puor9_7 =
-    rgb 128 115 172
+    rgb255 128 115 172
 
 
 {-| Provides the PuOr9-8 color.
 -}
 puor9_8 : Color
 puor9_8 =
-    rgb 84 39 136
+    rgb255 84 39 136
 
 
 {-| Provides the PuOr10 color scheme.
 -}
 puor10 : List Color
 puor10 =
-    [ rgb 127 59 8, rgb 179 88 6, rgb 224 130 20, rgb 253 184 99, rgb 254 224 182, rgb 216 218 235, rgb 178 171 210, rgb 128 115 172, rgb 84 39 136, rgb 45 0 75 ]
+    [ rgb255 127 59 8, rgb255 179 88 6, rgb255 224 130 20, rgb255 253 184 99, rgb255 254 224 182, rgb255 216 218 235, rgb255 178 171 210, rgb255 128 115 172, rgb255 84 39 136, rgb255 45 0 75 ]
 
 
 {-| Provides the PuOr10-0 color.
 -}
 puor10_0 : Color
 puor10_0 =
-    rgb 127 59 8
+    rgb255 127 59 8
 
 
 {-| Provides the PuOr10-1 color.
 -}
 puor10_1 : Color
 puor10_1 =
-    rgb 179 88 6
+    rgb255 179 88 6
 
 
 {-| Provides the PuOr10-2 color.
 -}
 puor10_2 : Color
 puor10_2 =
-    rgb 224 130 20
+    rgb255 224 130 20
 
 
 {-| Provides the PuOr10-3 color.
 -}
 puor10_3 : Color
 puor10_3 =
-    rgb 253 184 99
+    rgb255 253 184 99
 
 
 {-| Provides the PuOr10-4 color.
 -}
 puor10_4 : Color
 puor10_4 =
-    rgb 254 224 182
+    rgb255 254 224 182
 
 
 {-| Provides the PuOr10-5 color.
 -}
 puor10_5 : Color
 puor10_5 =
-    rgb 216 218 235
+    rgb255 216 218 235
 
 
 {-| Provides the PuOr10-6 color.
 -}
 puor10_6 : Color
 puor10_6 =
-    rgb 178 171 210
+    rgb255 178 171 210
 
 
 {-| Provides the PuOr10-7 color.
 -}
 puor10_7 : Color
 puor10_7 =
-    rgb 128 115 172
+    rgb255 128 115 172
 
 
 {-| Provides the PuOr10-8 color.
 -}
 puor10_8 : Color
 puor10_8 =
-    rgb 84 39 136
+    rgb255 84 39 136
 
 
 {-| Provides the PuOr10-9 color.
 -}
 puor10_9 : Color
 puor10_9 =
-    rgb 45 0 75
+    rgb255 45 0 75
 
 
 {-| Provides the PuOr11 color scheme.
 -}
 puor11 : List Color
 puor11 =
-    [ rgb 127 59 8, rgb 179 88 6, rgb 224 130 20, rgb 253 184 99, rgb 254 224 182, rgb 247 247 247, rgb 216 218 235, rgb 178 171 210, rgb 128 115 172, rgb 84 39 136, rgb 45 0 75 ]
+    [ rgb255 127 59 8, rgb255 179 88 6, rgb255 224 130 20, rgb255 253 184 99, rgb255 254 224 182, rgb255 247 247 247, rgb255 216 218 235, rgb255 178 171 210, rgb255 128 115 172, rgb255 84 39 136, rgb255 45 0 75 ]
 
 
 {-| Provides the PuOr11-0 color.
 -}
 puor11_0 : Color
 puor11_0 =
-    rgb 127 59 8
+    rgb255 127 59 8
 
 
 {-| Provides the PuOr11-1 color.
 -}
 puor11_1 : Color
 puor11_1 =
-    rgb 179 88 6
+    rgb255 179 88 6
 
 
 {-| Provides the PuOr11-2 color.
 -}
 puor11_2 : Color
 puor11_2 =
-    rgb 224 130 20
+    rgb255 224 130 20
 
 
 {-| Provides the PuOr11-3 color.
 -}
 puor11_3 : Color
 puor11_3 =
-    rgb 253 184 99
+    rgb255 253 184 99
 
 
 {-| Provides the PuOr11-4 color.
 -}
 puor11_4 : Color
 puor11_4 =
-    rgb 254 224 182
+    rgb255 254 224 182
 
 
 {-| Provides the PuOr11-5 color.
 -}
 puor11_5 : Color
 puor11_5 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the PuOr11-6 color.
 -}
 puor11_6 : Color
 puor11_6 =
-    rgb 216 218 235
+    rgb255 216 218 235
 
 
 {-| Provides the PuOr11-7 color.
 -}
 puor11_7 : Color
 puor11_7 =
-    rgb 178 171 210
+    rgb255 178 171 210
 
 
 {-| Provides the PuOr11-8 color.
 -}
 puor11_8 : Color
 puor11_8 =
-    rgb 128 115 172
+    rgb255 128 115 172
 
 
 {-| Provides the PuOr11-9 color.
 -}
 puor11_9 : Color
 puor11_9 =
-    rgb 84 39 136
+    rgb255 84 39 136
 
 
 {-| Provides the PuOr11-10 color.
 -}
 puor11_10 : Color
 puor11_10 =
-    rgb 45 0 75
+    rgb255 45 0 75
 
 
 {-| Returns a Spectral color scheme.
@@ -4554,10 +4554,10 @@ spectral n =
             []
 
         1 ->
-            [ rgb 252 141 89 ]
+            [ rgb255 252 141 89 ]
 
         2 ->
-            [ rgb 252 141 89, rgb 255 255 191 ]
+            [ rgb255 252 141 89, rgb255 255 255 191 ]
 
         3 ->
             spectral3
@@ -4596,10 +4596,10 @@ rdylgn n =
             []
 
         1 ->
-            [ rgb 252 141 89 ]
+            [ rgb255 252 141 89 ]
 
         2 ->
-            [ rgb 252 141 89, rgb 255 255 191 ]
+            [ rgb255 252 141 89, rgb255 255 255 191 ]
 
         3 ->
             rdylgn3
@@ -4638,10 +4638,10 @@ rdbu n =
             []
 
         1 ->
-            [ rgb 239 138 98 ]
+            [ rgb255 239 138 98 ]
 
         2 ->
-            [ rgb 239 138 98, rgb 247 247 247 ]
+            [ rgb255 239 138 98, rgb255 247 247 247 ]
 
         3 ->
             rdbu3
@@ -4680,10 +4680,10 @@ piyg n =
             []
 
         1 ->
-            [ rgb 233 163 201 ]
+            [ rgb255 233 163 201 ]
 
         2 ->
-            [ rgb 233 163 201, rgb 247 247 247 ]
+            [ rgb255 233 163 201, rgb255 247 247 247 ]
 
         3 ->
             piyg3
@@ -4722,10 +4722,10 @@ prgn n =
             []
 
         1 ->
-            [ rgb 175 141 195 ]
+            [ rgb255 175 141 195 ]
 
         2 ->
-            [ rgb 175 141 195, rgb 247 247 247 ]
+            [ rgb255 175 141 195, rgb255 247 247 247 ]
 
         3 ->
             prgn3
@@ -4764,10 +4764,10 @@ rdylbu n =
             []
 
         1 ->
-            [ rgb 252 141 89 ]
+            [ rgb255 252 141 89 ]
 
         2 ->
-            [ rgb 252 141 89, rgb 255 255 191 ]
+            [ rgb255 252 141 89, rgb255 255 255 191 ]
 
         3 ->
             rdylbu3
@@ -4806,10 +4806,10 @@ brbg n =
             []
 
         1 ->
-            [ rgb 216 179 101 ]
+            [ rgb255 216 179 101 ]
 
         2 ->
-            [ rgb 216 179 101, rgb 245 245 245 ]
+            [ rgb255 216 179 101, rgb255 245 245 245 ]
 
         3 ->
             brbg3
@@ -4848,10 +4848,10 @@ rdgy n =
             []
 
         1 ->
-            [ rgb 239 138 98 ]
+            [ rgb255 239 138 98 ]
 
         2 ->
-            [ rgb 239 138 98, rgb 255 255 255 ]
+            [ rgb255 239 138 98, rgb255 255 255 255 ]
 
         3 ->
             rdgy3
@@ -4890,10 +4890,10 @@ puor n =
             []
 
         1 ->
-            [ rgb 241 163 64 ]
+            [ rgb255 241 163 64 ]
 
         2 ->
-            [ rgb 241 163 64, rgb 247 247 247 ]
+            [ rgb255 241 163 64, rgb255 247 247 247 ]
 
         3 ->
             puor3

--- a/src/Colorbrewer/Qualitative.elm
+++ b/src/Colorbrewer/Qualitative.elm
@@ -6,2975 +6,2975 @@ module Colorbrewer.Qualitative exposing (set23_0, set23_1, set23_2, set23, set24
 
 -}
 
-import Color exposing (Color, rgb)
+import Color exposing (Color, rgb255)
 
 
 {-| Provides the Set23 color scheme.
 -}
 set23 : List Color
 set23 =
-    [ rgb 102 194 165, rgb 252 141 98, rgb 141 160 203 ]
+    [ rgb255 102 194 165, rgb255 252 141 98, rgb255 141 160 203 ]
 
 
 {-| Provides the Set23-0 color.
 -}
 set23_0 : Color
 set23_0 =
-    rgb 102 194 165
+    rgb255 102 194 165
 
 
 {-| Provides the Set23-1 color.
 -}
 set23_1 : Color
 set23_1 =
-    rgb 252 141 98
+    rgb255 252 141 98
 
 
 {-| Provides the Set23-2 color.
 -}
 set23_2 : Color
 set23_2 =
-    rgb 141 160 203
+    rgb255 141 160 203
 
 
 {-| Provides the Set24 color scheme.
 -}
 set24 : List Color
 set24 =
-    [ rgb 102 194 165, rgb 252 141 98, rgb 141 160 203, rgb 231 138 195 ]
+    [ rgb255 102 194 165, rgb255 252 141 98, rgb255 141 160 203, rgb255 231 138 195 ]
 
 
 {-| Provides the Set24-0 color.
 -}
 set24_0 : Color
 set24_0 =
-    rgb 102 194 165
+    rgb255 102 194 165
 
 
 {-| Provides the Set24-1 color.
 -}
 set24_1 : Color
 set24_1 =
-    rgb 252 141 98
+    rgb255 252 141 98
 
 
 {-| Provides the Set24-2 color.
 -}
 set24_2 : Color
 set24_2 =
-    rgb 141 160 203
+    rgb255 141 160 203
 
 
 {-| Provides the Set24-3 color.
 -}
 set24_3 : Color
 set24_3 =
-    rgb 231 138 195
+    rgb255 231 138 195
 
 
 {-| Provides the Set25 color scheme.
 -}
 set25 : List Color
 set25 =
-    [ rgb 102 194 165, rgb 252 141 98, rgb 141 160 203, rgb 231 138 195, rgb 166 216 84 ]
+    [ rgb255 102 194 165, rgb255 252 141 98, rgb255 141 160 203, rgb255 231 138 195, rgb255 166 216 84 ]
 
 
 {-| Provides the Set25-0 color.
 -}
 set25_0 : Color
 set25_0 =
-    rgb 102 194 165
+    rgb255 102 194 165
 
 
 {-| Provides the Set25-1 color.
 -}
 set25_1 : Color
 set25_1 =
-    rgb 252 141 98
+    rgb255 252 141 98
 
 
 {-| Provides the Set25-2 color.
 -}
 set25_2 : Color
 set25_2 =
-    rgb 141 160 203
+    rgb255 141 160 203
 
 
 {-| Provides the Set25-3 color.
 -}
 set25_3 : Color
 set25_3 =
-    rgb 231 138 195
+    rgb255 231 138 195
 
 
 {-| Provides the Set25-4 color.
 -}
 set25_4 : Color
 set25_4 =
-    rgb 166 216 84
+    rgb255 166 216 84
 
 
 {-| Provides the Set26 color scheme.
 -}
 set26 : List Color
 set26 =
-    [ rgb 102 194 165, rgb 252 141 98, rgb 141 160 203, rgb 231 138 195, rgb 166 216 84, rgb 255 217 47 ]
+    [ rgb255 102 194 165, rgb255 252 141 98, rgb255 141 160 203, rgb255 231 138 195, rgb255 166 216 84, rgb255 255 217 47 ]
 
 
 {-| Provides the Set26-0 color.
 -}
 set26_0 : Color
 set26_0 =
-    rgb 102 194 165
+    rgb255 102 194 165
 
 
 {-| Provides the Set26-1 color.
 -}
 set26_1 : Color
 set26_1 =
-    rgb 252 141 98
+    rgb255 252 141 98
 
 
 {-| Provides the Set26-2 color.
 -}
 set26_2 : Color
 set26_2 =
-    rgb 141 160 203
+    rgb255 141 160 203
 
 
 {-| Provides the Set26-3 color.
 -}
 set26_3 : Color
 set26_3 =
-    rgb 231 138 195
+    rgb255 231 138 195
 
 
 {-| Provides the Set26-4 color.
 -}
 set26_4 : Color
 set26_4 =
-    rgb 166 216 84
+    rgb255 166 216 84
 
 
 {-| Provides the Set26-5 color.
 -}
 set26_5 : Color
 set26_5 =
-    rgb 255 217 47
+    rgb255 255 217 47
 
 
 {-| Provides the Set27 color scheme.
 -}
 set27 : List Color
 set27 =
-    [ rgb 102 194 165, rgb 252 141 98, rgb 141 160 203, rgb 231 138 195, rgb 166 216 84, rgb 255 217 47, rgb 229 196 148 ]
+    [ rgb255 102 194 165, rgb255 252 141 98, rgb255 141 160 203, rgb255 231 138 195, rgb255 166 216 84, rgb255 255 217 47, rgb255 229 196 148 ]
 
 
 {-| Provides the Set27-0 color.
 -}
 set27_0 : Color
 set27_0 =
-    rgb 102 194 165
+    rgb255 102 194 165
 
 
 {-| Provides the Set27-1 color.
 -}
 set27_1 : Color
 set27_1 =
-    rgb 252 141 98
+    rgb255 252 141 98
 
 
 {-| Provides the Set27-2 color.
 -}
 set27_2 : Color
 set27_2 =
-    rgb 141 160 203
+    rgb255 141 160 203
 
 
 {-| Provides the Set27-3 color.
 -}
 set27_3 : Color
 set27_3 =
-    rgb 231 138 195
+    rgb255 231 138 195
 
 
 {-| Provides the Set27-4 color.
 -}
 set27_4 : Color
 set27_4 =
-    rgb 166 216 84
+    rgb255 166 216 84
 
 
 {-| Provides the Set27-5 color.
 -}
 set27_5 : Color
 set27_5 =
-    rgb 255 217 47
+    rgb255 255 217 47
 
 
 {-| Provides the Set27-6 color.
 -}
 set27_6 : Color
 set27_6 =
-    rgb 229 196 148
+    rgb255 229 196 148
 
 
 {-| Provides the Set28 color scheme.
 -}
 set28 : List Color
 set28 =
-    [ rgb 102 194 165, rgb 252 141 98, rgb 141 160 203, rgb 231 138 195, rgb 166 216 84, rgb 255 217 47, rgb 229 196 148, rgb 179 179 179 ]
+    [ rgb255 102 194 165, rgb255 252 141 98, rgb255 141 160 203, rgb255 231 138 195, rgb255 166 216 84, rgb255 255 217 47, rgb255 229 196 148, rgb255 179 179 179 ]
 
 
 {-| Provides the Set28-0 color.
 -}
 set28_0 : Color
 set28_0 =
-    rgb 102 194 165
+    rgb255 102 194 165
 
 
 {-| Provides the Set28-1 color.
 -}
 set28_1 : Color
 set28_1 =
-    rgb 252 141 98
+    rgb255 252 141 98
 
 
 {-| Provides the Set28-2 color.
 -}
 set28_2 : Color
 set28_2 =
-    rgb 141 160 203
+    rgb255 141 160 203
 
 
 {-| Provides the Set28-3 color.
 -}
 set28_3 : Color
 set28_3 =
-    rgb 231 138 195
+    rgb255 231 138 195
 
 
 {-| Provides the Set28-4 color.
 -}
 set28_4 : Color
 set28_4 =
-    rgb 166 216 84
+    rgb255 166 216 84
 
 
 {-| Provides the Set28-5 color.
 -}
 set28_5 : Color
 set28_5 =
-    rgb 255 217 47
+    rgb255 255 217 47
 
 
 {-| Provides the Set28-6 color.
 -}
 set28_6 : Color
 set28_6 =
-    rgb 229 196 148
+    rgb255 229 196 148
 
 
 {-| Provides the Set28-7 color.
 -}
 set28_7 : Color
 set28_7 =
-    rgb 179 179 179
+    rgb255 179 179 179
 
 
 {-| Provides the Accent3 color scheme.
 -}
 accent3 : List Color
 accent3 =
-    [ rgb 127 201 127, rgb 190 174 212, rgb 253 192 134 ]
+    [ rgb255 127 201 127, rgb255 190 174 212, rgb255 253 192 134 ]
 
 
 {-| Provides the Accent3-0 color.
 -}
 accent3_0 : Color
 accent3_0 =
-    rgb 127 201 127
+    rgb255 127 201 127
 
 
 {-| Provides the Accent3-1 color.
 -}
 accent3_1 : Color
 accent3_1 =
-    rgb 190 174 212
+    rgb255 190 174 212
 
 
 {-| Provides the Accent3-2 color.
 -}
 accent3_2 : Color
 accent3_2 =
-    rgb 253 192 134
+    rgb255 253 192 134
 
 
 {-| Provides the Accent4 color scheme.
 -}
 accent4 : List Color
 accent4 =
-    [ rgb 127 201 127, rgb 190 174 212, rgb 253 192 134, rgb 255 255 153 ]
+    [ rgb255 127 201 127, rgb255 190 174 212, rgb255 253 192 134, rgb255 255 255 153 ]
 
 
 {-| Provides the Accent4-0 color.
 -}
 accent4_0 : Color
 accent4_0 =
-    rgb 127 201 127
+    rgb255 127 201 127
 
 
 {-| Provides the Accent4-1 color.
 -}
 accent4_1 : Color
 accent4_1 =
-    rgb 190 174 212
+    rgb255 190 174 212
 
 
 {-| Provides the Accent4-2 color.
 -}
 accent4_2 : Color
 accent4_2 =
-    rgb 253 192 134
+    rgb255 253 192 134
 
 
 {-| Provides the Accent4-3 color.
 -}
 accent4_3 : Color
 accent4_3 =
-    rgb 255 255 153
+    rgb255 255 255 153
 
 
 {-| Provides the Accent5 color scheme.
 -}
 accent5 : List Color
 accent5 =
-    [ rgb 127 201 127, rgb 190 174 212, rgb 253 192 134, rgb 255 255 153, rgb 56 108 176 ]
+    [ rgb255 127 201 127, rgb255 190 174 212, rgb255 253 192 134, rgb255 255 255 153, rgb255 56 108 176 ]
 
 
 {-| Provides the Accent5-0 color.
 -}
 accent5_0 : Color
 accent5_0 =
-    rgb 127 201 127
+    rgb255 127 201 127
 
 
 {-| Provides the Accent5-1 color.
 -}
 accent5_1 : Color
 accent5_1 =
-    rgb 190 174 212
+    rgb255 190 174 212
 
 
 {-| Provides the Accent5-2 color.
 -}
 accent5_2 : Color
 accent5_2 =
-    rgb 253 192 134
+    rgb255 253 192 134
 
 
 {-| Provides the Accent5-3 color.
 -}
 accent5_3 : Color
 accent5_3 =
-    rgb 255 255 153
+    rgb255 255 255 153
 
 
 {-| Provides the Accent5-4 color.
 -}
 accent5_4 : Color
 accent5_4 =
-    rgb 56 108 176
+    rgb255 56 108 176
 
 
 {-| Provides the Accent6 color scheme.
 -}
 accent6 : List Color
 accent6 =
-    [ rgb 127 201 127, rgb 190 174 212, rgb 253 192 134, rgb 255 255 153, rgb 56 108 176, rgb 240 2 127 ]
+    [ rgb255 127 201 127, rgb255 190 174 212, rgb255 253 192 134, rgb255 255 255 153, rgb255 56 108 176, rgb255 240 2 127 ]
 
 
 {-| Provides the Accent6-0 color.
 -}
 accent6_0 : Color
 accent6_0 =
-    rgb 127 201 127
+    rgb255 127 201 127
 
 
 {-| Provides the Accent6-1 color.
 -}
 accent6_1 : Color
 accent6_1 =
-    rgb 190 174 212
+    rgb255 190 174 212
 
 
 {-| Provides the Accent6-2 color.
 -}
 accent6_2 : Color
 accent6_2 =
-    rgb 253 192 134
+    rgb255 253 192 134
 
 
 {-| Provides the Accent6-3 color.
 -}
 accent6_3 : Color
 accent6_3 =
-    rgb 255 255 153
+    rgb255 255 255 153
 
 
 {-| Provides the Accent6-4 color.
 -}
 accent6_4 : Color
 accent6_4 =
-    rgb 56 108 176
+    rgb255 56 108 176
 
 
 {-| Provides the Accent6-5 color.
 -}
 accent6_5 : Color
 accent6_5 =
-    rgb 240 2 127
+    rgb255 240 2 127
 
 
 {-| Provides the Accent7 color scheme.
 -}
 accent7 : List Color
 accent7 =
-    [ rgb 127 201 127, rgb 190 174 212, rgb 253 192 134, rgb 255 255 153, rgb 56 108 176, rgb 240 2 127, rgb 191 91 23 ]
+    [ rgb255 127 201 127, rgb255 190 174 212, rgb255 253 192 134, rgb255 255 255 153, rgb255 56 108 176, rgb255 240 2 127, rgb255 191 91 23 ]
 
 
 {-| Provides the Accent7-0 color.
 -}
 accent7_0 : Color
 accent7_0 =
-    rgb 127 201 127
+    rgb255 127 201 127
 
 
 {-| Provides the Accent7-1 color.
 -}
 accent7_1 : Color
 accent7_1 =
-    rgb 190 174 212
+    rgb255 190 174 212
 
 
 {-| Provides the Accent7-2 color.
 -}
 accent7_2 : Color
 accent7_2 =
-    rgb 253 192 134
+    rgb255 253 192 134
 
 
 {-| Provides the Accent7-3 color.
 -}
 accent7_3 : Color
 accent7_3 =
-    rgb 255 255 153
+    rgb255 255 255 153
 
 
 {-| Provides the Accent7-4 color.
 -}
 accent7_4 : Color
 accent7_4 =
-    rgb 56 108 176
+    rgb255 56 108 176
 
 
 {-| Provides the Accent7-5 color.
 -}
 accent7_5 : Color
 accent7_5 =
-    rgb 240 2 127
+    rgb255 240 2 127
 
 
 {-| Provides the Accent7-6 color.
 -}
 accent7_6 : Color
 accent7_6 =
-    rgb 191 91 23
+    rgb255 191 91 23
 
 
 {-| Provides the Accent8 color scheme.
 -}
 accent8 : List Color
 accent8 =
-    [ rgb 127 201 127, rgb 190 174 212, rgb 253 192 134, rgb 255 255 153, rgb 56 108 176, rgb 240 2 127, rgb 191 91 23, rgb 102 102 102 ]
+    [ rgb255 127 201 127, rgb255 190 174 212, rgb255 253 192 134, rgb255 255 255 153, rgb255 56 108 176, rgb255 240 2 127, rgb255 191 91 23, rgb255 102 102 102 ]
 
 
 {-| Provides the Accent8-0 color.
 -}
 accent8_0 : Color
 accent8_0 =
-    rgb 127 201 127
+    rgb255 127 201 127
 
 
 {-| Provides the Accent8-1 color.
 -}
 accent8_1 : Color
 accent8_1 =
-    rgb 190 174 212
+    rgb255 190 174 212
 
 
 {-| Provides the Accent8-2 color.
 -}
 accent8_2 : Color
 accent8_2 =
-    rgb 253 192 134
+    rgb255 253 192 134
 
 
 {-| Provides the Accent8-3 color.
 -}
 accent8_3 : Color
 accent8_3 =
-    rgb 255 255 153
+    rgb255 255 255 153
 
 
 {-| Provides the Accent8-4 color.
 -}
 accent8_4 : Color
 accent8_4 =
-    rgb 56 108 176
+    rgb255 56 108 176
 
 
 {-| Provides the Accent8-5 color.
 -}
 accent8_5 : Color
 accent8_5 =
-    rgb 240 2 127
+    rgb255 240 2 127
 
 
 {-| Provides the Accent8-6 color.
 -}
 accent8_6 : Color
 accent8_6 =
-    rgb 191 91 23
+    rgb255 191 91 23
 
 
 {-| Provides the Accent8-7 color.
 -}
 accent8_7 : Color
 accent8_7 =
-    rgb 102 102 102
+    rgb255 102 102 102
 
 
 {-| Provides the Set13 color scheme.
 -}
 set13 : List Color
 set13 =
-    [ rgb 228 26 28, rgb 55 126 184, rgb 77 175 74 ]
+    [ rgb255 228 26 28, rgb255 55 126 184, rgb255 77 175 74 ]
 
 
 {-| Provides the Set13-0 color.
 -}
 set13_0 : Color
 set13_0 =
-    rgb 228 26 28
+    rgb255 228 26 28
 
 
 {-| Provides the Set13-1 color.
 -}
 set13_1 : Color
 set13_1 =
-    rgb 55 126 184
+    rgb255 55 126 184
 
 
 {-| Provides the Set13-2 color.
 -}
 set13_2 : Color
 set13_2 =
-    rgb 77 175 74
+    rgb255 77 175 74
 
 
 {-| Provides the Set14 color scheme.
 -}
 set14 : List Color
 set14 =
-    [ rgb 228 26 28, rgb 55 126 184, rgb 77 175 74, rgb 152 78 163 ]
+    [ rgb255 228 26 28, rgb255 55 126 184, rgb255 77 175 74, rgb255 152 78 163 ]
 
 
 {-| Provides the Set14-0 color.
 -}
 set14_0 : Color
 set14_0 =
-    rgb 228 26 28
+    rgb255 228 26 28
 
 
 {-| Provides the Set14-1 color.
 -}
 set14_1 : Color
 set14_1 =
-    rgb 55 126 184
+    rgb255 55 126 184
 
 
 {-| Provides the Set14-2 color.
 -}
 set14_2 : Color
 set14_2 =
-    rgb 77 175 74
+    rgb255 77 175 74
 
 
 {-| Provides the Set14-3 color.
 -}
 set14_3 : Color
 set14_3 =
-    rgb 152 78 163
+    rgb255 152 78 163
 
 
 {-| Provides the Set15 color scheme.
 -}
 set15 : List Color
 set15 =
-    [ rgb 228 26 28, rgb 55 126 184, rgb 77 175 74, rgb 152 78 163, rgb 255 127 0 ]
+    [ rgb255 228 26 28, rgb255 55 126 184, rgb255 77 175 74, rgb255 152 78 163, rgb255 255 127 0 ]
 
 
 {-| Provides the Set15-0 color.
 -}
 set15_0 : Color
 set15_0 =
-    rgb 228 26 28
+    rgb255 228 26 28
 
 
 {-| Provides the Set15-1 color.
 -}
 set15_1 : Color
 set15_1 =
-    rgb 55 126 184
+    rgb255 55 126 184
 
 
 {-| Provides the Set15-2 color.
 -}
 set15_2 : Color
 set15_2 =
-    rgb 77 175 74
+    rgb255 77 175 74
 
 
 {-| Provides the Set15-3 color.
 -}
 set15_3 : Color
 set15_3 =
-    rgb 152 78 163
+    rgb255 152 78 163
 
 
 {-| Provides the Set15-4 color.
 -}
 set15_4 : Color
 set15_4 =
-    rgb 255 127 0
+    rgb255 255 127 0
 
 
 {-| Provides the Set16 color scheme.
 -}
 set16 : List Color
 set16 =
-    [ rgb 228 26 28, rgb 55 126 184, rgb 77 175 74, rgb 152 78 163, rgb 255 127 0, rgb 255 255 51 ]
+    [ rgb255 228 26 28, rgb255 55 126 184, rgb255 77 175 74, rgb255 152 78 163, rgb255 255 127 0, rgb255 255 255 51 ]
 
 
 {-| Provides the Set16-0 color.
 -}
 set16_0 : Color
 set16_0 =
-    rgb 228 26 28
+    rgb255 228 26 28
 
 
 {-| Provides the Set16-1 color.
 -}
 set16_1 : Color
 set16_1 =
-    rgb 55 126 184
+    rgb255 55 126 184
 
 
 {-| Provides the Set16-2 color.
 -}
 set16_2 : Color
 set16_2 =
-    rgb 77 175 74
+    rgb255 77 175 74
 
 
 {-| Provides the Set16-3 color.
 -}
 set16_3 : Color
 set16_3 =
-    rgb 152 78 163
+    rgb255 152 78 163
 
 
 {-| Provides the Set16-4 color.
 -}
 set16_4 : Color
 set16_4 =
-    rgb 255 127 0
+    rgb255 255 127 0
 
 
 {-| Provides the Set16-5 color.
 -}
 set16_5 : Color
 set16_5 =
-    rgb 255 255 51
+    rgb255 255 255 51
 
 
 {-| Provides the Set17 color scheme.
 -}
 set17 : List Color
 set17 =
-    [ rgb 228 26 28, rgb 55 126 184, rgb 77 175 74, rgb 152 78 163, rgb 255 127 0, rgb 255 255 51, rgb 166 86 40 ]
+    [ rgb255 228 26 28, rgb255 55 126 184, rgb255 77 175 74, rgb255 152 78 163, rgb255 255 127 0, rgb255 255 255 51, rgb255 166 86 40 ]
 
 
 {-| Provides the Set17-0 color.
 -}
 set17_0 : Color
 set17_0 =
-    rgb 228 26 28
+    rgb255 228 26 28
 
 
 {-| Provides the Set17-1 color.
 -}
 set17_1 : Color
 set17_1 =
-    rgb 55 126 184
+    rgb255 55 126 184
 
 
 {-| Provides the Set17-2 color.
 -}
 set17_2 : Color
 set17_2 =
-    rgb 77 175 74
+    rgb255 77 175 74
 
 
 {-| Provides the Set17-3 color.
 -}
 set17_3 : Color
 set17_3 =
-    rgb 152 78 163
+    rgb255 152 78 163
 
 
 {-| Provides the Set17-4 color.
 -}
 set17_4 : Color
 set17_4 =
-    rgb 255 127 0
+    rgb255 255 127 0
 
 
 {-| Provides the Set17-5 color.
 -}
 set17_5 : Color
 set17_5 =
-    rgb 255 255 51
+    rgb255 255 255 51
 
 
 {-| Provides the Set17-6 color.
 -}
 set17_6 : Color
 set17_6 =
-    rgb 166 86 40
+    rgb255 166 86 40
 
 
 {-| Provides the Set18 color scheme.
 -}
 set18 : List Color
 set18 =
-    [ rgb 228 26 28, rgb 55 126 184, rgb 77 175 74, rgb 152 78 163, rgb 255 127 0, rgb 255 255 51, rgb 166 86 40, rgb 247 129 191 ]
+    [ rgb255 228 26 28, rgb255 55 126 184, rgb255 77 175 74, rgb255 152 78 163, rgb255 255 127 0, rgb255 255 255 51, rgb255 166 86 40, rgb255 247 129 191 ]
 
 
 {-| Provides the Set18-0 color.
 -}
 set18_0 : Color
 set18_0 =
-    rgb 228 26 28
+    rgb255 228 26 28
 
 
 {-| Provides the Set18-1 color.
 -}
 set18_1 : Color
 set18_1 =
-    rgb 55 126 184
+    rgb255 55 126 184
 
 
 {-| Provides the Set18-2 color.
 -}
 set18_2 : Color
 set18_2 =
-    rgb 77 175 74
+    rgb255 77 175 74
 
 
 {-| Provides the Set18-3 color.
 -}
 set18_3 : Color
 set18_3 =
-    rgb 152 78 163
+    rgb255 152 78 163
 
 
 {-| Provides the Set18-4 color.
 -}
 set18_4 : Color
 set18_4 =
-    rgb 255 127 0
+    rgb255 255 127 0
 
 
 {-| Provides the Set18-5 color.
 -}
 set18_5 : Color
 set18_5 =
-    rgb 255 255 51
+    rgb255 255 255 51
 
 
 {-| Provides the Set18-6 color.
 -}
 set18_6 : Color
 set18_6 =
-    rgb 166 86 40
+    rgb255 166 86 40
 
 
 {-| Provides the Set18-7 color.
 -}
 set18_7 : Color
 set18_7 =
-    rgb 247 129 191
+    rgb255 247 129 191
 
 
 {-| Provides the Set19 color scheme.
 -}
 set19 : List Color
 set19 =
-    [ rgb 228 26 28, rgb 55 126 184, rgb 77 175 74, rgb 152 78 163, rgb 255 127 0, rgb 255 255 51, rgb 166 86 40, rgb 247 129 191, rgb 153 153 153 ]
+    [ rgb255 228 26 28, rgb255 55 126 184, rgb255 77 175 74, rgb255 152 78 163, rgb255 255 127 0, rgb255 255 255 51, rgb255 166 86 40, rgb255 247 129 191, rgb255 153 153 153 ]
 
 
 {-| Provides the Set19-0 color.
 -}
 set19_0 : Color
 set19_0 =
-    rgb 228 26 28
+    rgb255 228 26 28
 
 
 {-| Provides the Set19-1 color.
 -}
 set19_1 : Color
 set19_1 =
-    rgb 55 126 184
+    rgb255 55 126 184
 
 
 {-| Provides the Set19-2 color.
 -}
 set19_2 : Color
 set19_2 =
-    rgb 77 175 74
+    rgb255 77 175 74
 
 
 {-| Provides the Set19-3 color.
 -}
 set19_3 : Color
 set19_3 =
-    rgb 152 78 163
+    rgb255 152 78 163
 
 
 {-| Provides the Set19-4 color.
 -}
 set19_4 : Color
 set19_4 =
-    rgb 255 127 0
+    rgb255 255 127 0
 
 
 {-| Provides the Set19-5 color.
 -}
 set19_5 : Color
 set19_5 =
-    rgb 255 255 51
+    rgb255 255 255 51
 
 
 {-| Provides the Set19-6 color.
 -}
 set19_6 : Color
 set19_6 =
-    rgb 166 86 40
+    rgb255 166 86 40
 
 
 {-| Provides the Set19-7 color.
 -}
 set19_7 : Color
 set19_7 =
-    rgb 247 129 191
+    rgb255 247 129 191
 
 
 {-| Provides the Set19-8 color.
 -}
 set19_8 : Color
 set19_8 =
-    rgb 153 153 153
+    rgb255 153 153 153
 
 
 {-| Provides the Set33 color scheme.
 -}
 set33 : List Color
 set33 =
-    [ rgb 141 211 199, rgb 255 255 179, rgb 190 186 218 ]
+    [ rgb255 141 211 199, rgb255 255 255 179, rgb255 190 186 218 ]
 
 
 {-| Provides the Set33-0 color.
 -}
 set33_0 : Color
 set33_0 =
-    rgb 141 211 199
+    rgb255 141 211 199
 
 
 {-| Provides the Set33-1 color.
 -}
 set33_1 : Color
 set33_1 =
-    rgb 255 255 179
+    rgb255 255 255 179
 
 
 {-| Provides the Set33-2 color.
 -}
 set33_2 : Color
 set33_2 =
-    rgb 190 186 218
+    rgb255 190 186 218
 
 
 {-| Provides the Set34 color scheme.
 -}
 set34 : List Color
 set34 =
-    [ rgb 141 211 199, rgb 255 255 179, rgb 190 186 218, rgb 251 128 114 ]
+    [ rgb255 141 211 199, rgb255 255 255 179, rgb255 190 186 218, rgb255 251 128 114 ]
 
 
 {-| Provides the Set34-0 color.
 -}
 set34_0 : Color
 set34_0 =
-    rgb 141 211 199
+    rgb255 141 211 199
 
 
 {-| Provides the Set34-1 color.
 -}
 set34_1 : Color
 set34_1 =
-    rgb 255 255 179
+    rgb255 255 255 179
 
 
 {-| Provides the Set34-2 color.
 -}
 set34_2 : Color
 set34_2 =
-    rgb 190 186 218
+    rgb255 190 186 218
 
 
 {-| Provides the Set34-3 color.
 -}
 set34_3 : Color
 set34_3 =
-    rgb 251 128 114
+    rgb255 251 128 114
 
 
 {-| Provides the Set35 color scheme.
 -}
 set35 : List Color
 set35 =
-    [ rgb 141 211 199, rgb 255 255 179, rgb 190 186 218, rgb 251 128 114, rgb 128 177 211 ]
+    [ rgb255 141 211 199, rgb255 255 255 179, rgb255 190 186 218, rgb255 251 128 114, rgb255 128 177 211 ]
 
 
 {-| Provides the Set35-0 color.
 -}
 set35_0 : Color
 set35_0 =
-    rgb 141 211 199
+    rgb255 141 211 199
 
 
 {-| Provides the Set35-1 color.
 -}
 set35_1 : Color
 set35_1 =
-    rgb 255 255 179
+    rgb255 255 255 179
 
 
 {-| Provides the Set35-2 color.
 -}
 set35_2 : Color
 set35_2 =
-    rgb 190 186 218
+    rgb255 190 186 218
 
 
 {-| Provides the Set35-3 color.
 -}
 set35_3 : Color
 set35_3 =
-    rgb 251 128 114
+    rgb255 251 128 114
 
 
 {-| Provides the Set35-4 color.
 -}
 set35_4 : Color
 set35_4 =
-    rgb 128 177 211
+    rgb255 128 177 211
 
 
 {-| Provides the Set36 color scheme.
 -}
 set36 : List Color
 set36 =
-    [ rgb 141 211 199, rgb 255 255 179, rgb 190 186 218, rgb 251 128 114, rgb 128 177 211, rgb 253 180 98 ]
+    [ rgb255 141 211 199, rgb255 255 255 179, rgb255 190 186 218, rgb255 251 128 114, rgb255 128 177 211, rgb255 253 180 98 ]
 
 
 {-| Provides the Set36-0 color.
 -}
 set36_0 : Color
 set36_0 =
-    rgb 141 211 199
+    rgb255 141 211 199
 
 
 {-| Provides the Set36-1 color.
 -}
 set36_1 : Color
 set36_1 =
-    rgb 255 255 179
+    rgb255 255 255 179
 
 
 {-| Provides the Set36-2 color.
 -}
 set36_2 : Color
 set36_2 =
-    rgb 190 186 218
+    rgb255 190 186 218
 
 
 {-| Provides the Set36-3 color.
 -}
 set36_3 : Color
 set36_3 =
-    rgb 251 128 114
+    rgb255 251 128 114
 
 
 {-| Provides the Set36-4 color.
 -}
 set36_4 : Color
 set36_4 =
-    rgb 128 177 211
+    rgb255 128 177 211
 
 
 {-| Provides the Set36-5 color.
 -}
 set36_5 : Color
 set36_5 =
-    rgb 253 180 98
+    rgb255 253 180 98
 
 
 {-| Provides the Set37 color scheme.
 -}
 set37 : List Color
 set37 =
-    [ rgb 141 211 199, rgb 255 255 179, rgb 190 186 218, rgb 251 128 114, rgb 128 177 211, rgb 253 180 98, rgb 179 222 105 ]
+    [ rgb255 141 211 199, rgb255 255 255 179, rgb255 190 186 218, rgb255 251 128 114, rgb255 128 177 211, rgb255 253 180 98, rgb255 179 222 105 ]
 
 
 {-| Provides the Set37-0 color.
 -}
 set37_0 : Color
 set37_0 =
-    rgb 141 211 199
+    rgb255 141 211 199
 
 
 {-| Provides the Set37-1 color.
 -}
 set37_1 : Color
 set37_1 =
-    rgb 255 255 179
+    rgb255 255 255 179
 
 
 {-| Provides the Set37-2 color.
 -}
 set37_2 : Color
 set37_2 =
-    rgb 190 186 218
+    rgb255 190 186 218
 
 
 {-| Provides the Set37-3 color.
 -}
 set37_3 : Color
 set37_3 =
-    rgb 251 128 114
+    rgb255 251 128 114
 
 
 {-| Provides the Set37-4 color.
 -}
 set37_4 : Color
 set37_4 =
-    rgb 128 177 211
+    rgb255 128 177 211
 
 
 {-| Provides the Set37-5 color.
 -}
 set37_5 : Color
 set37_5 =
-    rgb 253 180 98
+    rgb255 253 180 98
 
 
 {-| Provides the Set37-6 color.
 -}
 set37_6 : Color
 set37_6 =
-    rgb 179 222 105
+    rgb255 179 222 105
 
 
 {-| Provides the Set38 color scheme.
 -}
 set38 : List Color
 set38 =
-    [ rgb 141 211 199, rgb 255 255 179, rgb 190 186 218, rgb 251 128 114, rgb 128 177 211, rgb 253 180 98, rgb 179 222 105, rgb 252 205 229 ]
+    [ rgb255 141 211 199, rgb255 255 255 179, rgb255 190 186 218, rgb255 251 128 114, rgb255 128 177 211, rgb255 253 180 98, rgb255 179 222 105, rgb255 252 205 229 ]
 
 
 {-| Provides the Set38-0 color.
 -}
 set38_0 : Color
 set38_0 =
-    rgb 141 211 199
+    rgb255 141 211 199
 
 
 {-| Provides the Set38-1 color.
 -}
 set38_1 : Color
 set38_1 =
-    rgb 255 255 179
+    rgb255 255 255 179
 
 
 {-| Provides the Set38-2 color.
 -}
 set38_2 : Color
 set38_2 =
-    rgb 190 186 218
+    rgb255 190 186 218
 
 
 {-| Provides the Set38-3 color.
 -}
 set38_3 : Color
 set38_3 =
-    rgb 251 128 114
+    rgb255 251 128 114
 
 
 {-| Provides the Set38-4 color.
 -}
 set38_4 : Color
 set38_4 =
-    rgb 128 177 211
+    rgb255 128 177 211
 
 
 {-| Provides the Set38-5 color.
 -}
 set38_5 : Color
 set38_5 =
-    rgb 253 180 98
+    rgb255 253 180 98
 
 
 {-| Provides the Set38-6 color.
 -}
 set38_6 : Color
 set38_6 =
-    rgb 179 222 105
+    rgb255 179 222 105
 
 
 {-| Provides the Set38-7 color.
 -}
 set38_7 : Color
 set38_7 =
-    rgb 252 205 229
+    rgb255 252 205 229
 
 
 {-| Provides the Set39 color scheme.
 -}
 set39 : List Color
 set39 =
-    [ rgb 141 211 199, rgb 255 255 179, rgb 190 186 218, rgb 251 128 114, rgb 128 177 211, rgb 253 180 98, rgb 179 222 105, rgb 252 205 229, rgb 217 217 217 ]
+    [ rgb255 141 211 199, rgb255 255 255 179, rgb255 190 186 218, rgb255 251 128 114, rgb255 128 177 211, rgb255 253 180 98, rgb255 179 222 105, rgb255 252 205 229, rgb255 217 217 217 ]
 
 
 {-| Provides the Set39-0 color.
 -}
 set39_0 : Color
 set39_0 =
-    rgb 141 211 199
+    rgb255 141 211 199
 
 
 {-| Provides the Set39-1 color.
 -}
 set39_1 : Color
 set39_1 =
-    rgb 255 255 179
+    rgb255 255 255 179
 
 
 {-| Provides the Set39-2 color.
 -}
 set39_2 : Color
 set39_2 =
-    rgb 190 186 218
+    rgb255 190 186 218
 
 
 {-| Provides the Set39-3 color.
 -}
 set39_3 : Color
 set39_3 =
-    rgb 251 128 114
+    rgb255 251 128 114
 
 
 {-| Provides the Set39-4 color.
 -}
 set39_4 : Color
 set39_4 =
-    rgb 128 177 211
+    rgb255 128 177 211
 
 
 {-| Provides the Set39-5 color.
 -}
 set39_5 : Color
 set39_5 =
-    rgb 253 180 98
+    rgb255 253 180 98
 
 
 {-| Provides the Set39-6 color.
 -}
 set39_6 : Color
 set39_6 =
-    rgb 179 222 105
+    rgb255 179 222 105
 
 
 {-| Provides the Set39-7 color.
 -}
 set39_7 : Color
 set39_7 =
-    rgb 252 205 229
+    rgb255 252 205 229
 
 
 {-| Provides the Set39-8 color.
 -}
 set39_8 : Color
 set39_8 =
-    rgb 217 217 217
+    rgb255 217 217 217
 
 
 {-| Provides the Set310 color scheme.
 -}
 set310 : List Color
 set310 =
-    [ rgb 141 211 199, rgb 255 255 179, rgb 190 186 218, rgb 251 128 114, rgb 128 177 211, rgb 253 180 98, rgb 179 222 105, rgb 252 205 229, rgb 217 217 217, rgb 188 128 189 ]
+    [ rgb255 141 211 199, rgb255 255 255 179, rgb255 190 186 218, rgb255 251 128 114, rgb255 128 177 211, rgb255 253 180 98, rgb255 179 222 105, rgb255 252 205 229, rgb255 217 217 217, rgb255 188 128 189 ]
 
 
 {-| Provides the Set310-0 color.
 -}
 set310_0 : Color
 set310_0 =
-    rgb 141 211 199
+    rgb255 141 211 199
 
 
 {-| Provides the Set310-1 color.
 -}
 set310_1 : Color
 set310_1 =
-    rgb 255 255 179
+    rgb255 255 255 179
 
 
 {-| Provides the Set310-2 color.
 -}
 set310_2 : Color
 set310_2 =
-    rgb 190 186 218
+    rgb255 190 186 218
 
 
 {-| Provides the Set310-3 color.
 -}
 set310_3 : Color
 set310_3 =
-    rgb 251 128 114
+    rgb255 251 128 114
 
 
 {-| Provides the Set310-4 color.
 -}
 set310_4 : Color
 set310_4 =
-    rgb 128 177 211
+    rgb255 128 177 211
 
 
 {-| Provides the Set310-5 color.
 -}
 set310_5 : Color
 set310_5 =
-    rgb 253 180 98
+    rgb255 253 180 98
 
 
 {-| Provides the Set310-6 color.
 -}
 set310_6 : Color
 set310_6 =
-    rgb 179 222 105
+    rgb255 179 222 105
 
 
 {-| Provides the Set310-7 color.
 -}
 set310_7 : Color
 set310_7 =
-    rgb 252 205 229
+    rgb255 252 205 229
 
 
 {-| Provides the Set310-8 color.
 -}
 set310_8 : Color
 set310_8 =
-    rgb 217 217 217
+    rgb255 217 217 217
 
 
 {-| Provides the Set310-9 color.
 -}
 set310_9 : Color
 set310_9 =
-    rgb 188 128 189
+    rgb255 188 128 189
 
 
 {-| Provides the Set311 color scheme.
 -}
 set311 : List Color
 set311 =
-    [ rgb 141 211 199, rgb 255 255 179, rgb 190 186 218, rgb 251 128 114, rgb 128 177 211, rgb 253 180 98, rgb 179 222 105, rgb 252 205 229, rgb 217 217 217, rgb 188 128 189, rgb 204 235 197 ]
+    [ rgb255 141 211 199, rgb255 255 255 179, rgb255 190 186 218, rgb255 251 128 114, rgb255 128 177 211, rgb255 253 180 98, rgb255 179 222 105, rgb255 252 205 229, rgb255 217 217 217, rgb255 188 128 189, rgb255 204 235 197 ]
 
 
 {-| Provides the Set311-0 color.
 -}
 set311_0 : Color
 set311_0 =
-    rgb 141 211 199
+    rgb255 141 211 199
 
 
 {-| Provides the Set311-1 color.
 -}
 set311_1 : Color
 set311_1 =
-    rgb 255 255 179
+    rgb255 255 255 179
 
 
 {-| Provides the Set311-2 color.
 -}
 set311_2 : Color
 set311_2 =
-    rgb 190 186 218
+    rgb255 190 186 218
 
 
 {-| Provides the Set311-3 color.
 -}
 set311_3 : Color
 set311_3 =
-    rgb 251 128 114
+    rgb255 251 128 114
 
 
 {-| Provides the Set311-4 color.
 -}
 set311_4 : Color
 set311_4 =
-    rgb 128 177 211
+    rgb255 128 177 211
 
 
 {-| Provides the Set311-5 color.
 -}
 set311_5 : Color
 set311_5 =
-    rgb 253 180 98
+    rgb255 253 180 98
 
 
 {-| Provides the Set311-6 color.
 -}
 set311_6 : Color
 set311_6 =
-    rgb 179 222 105
+    rgb255 179 222 105
 
 
 {-| Provides the Set311-7 color.
 -}
 set311_7 : Color
 set311_7 =
-    rgb 252 205 229
+    rgb255 252 205 229
 
 
 {-| Provides the Set311-8 color.
 -}
 set311_8 : Color
 set311_8 =
-    rgb 217 217 217
+    rgb255 217 217 217
 
 
 {-| Provides the Set311-9 color.
 -}
 set311_9 : Color
 set311_9 =
-    rgb 188 128 189
+    rgb255 188 128 189
 
 
 {-| Provides the Set311-10 color.
 -}
 set311_10 : Color
 set311_10 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the Set312 color scheme.
 -}
 set312 : List Color
 set312 =
-    [ rgb 141 211 199, rgb 255 255 179, rgb 190 186 218, rgb 251 128 114, rgb 128 177 211, rgb 253 180 98, rgb 179 222 105, rgb 252 205 229, rgb 217 217 217, rgb 188 128 189, rgb 204 235 197, rgb 255 237 111 ]
+    [ rgb255 141 211 199, rgb255 255 255 179, rgb255 190 186 218, rgb255 251 128 114, rgb255 128 177 211, rgb255 253 180 98, rgb255 179 222 105, rgb255 252 205 229, rgb255 217 217 217, rgb255 188 128 189, rgb255 204 235 197, rgb255 255 237 111 ]
 
 
 {-| Provides the Set312-0 color.
 -}
 set312_0 : Color
 set312_0 =
-    rgb 141 211 199
+    rgb255 141 211 199
 
 
 {-| Provides the Set312-1 color.
 -}
 set312_1 : Color
 set312_1 =
-    rgb 255 255 179
+    rgb255 255 255 179
 
 
 {-| Provides the Set312-2 color.
 -}
 set312_2 : Color
 set312_2 =
-    rgb 190 186 218
+    rgb255 190 186 218
 
 
 {-| Provides the Set312-3 color.
 -}
 set312_3 : Color
 set312_3 =
-    rgb 251 128 114
+    rgb255 251 128 114
 
 
 {-| Provides the Set312-4 color.
 -}
 set312_4 : Color
 set312_4 =
-    rgb 128 177 211
+    rgb255 128 177 211
 
 
 {-| Provides the Set312-5 color.
 -}
 set312_5 : Color
 set312_5 =
-    rgb 253 180 98
+    rgb255 253 180 98
 
 
 {-| Provides the Set312-6 color.
 -}
 set312_6 : Color
 set312_6 =
-    rgb 179 222 105
+    rgb255 179 222 105
 
 
 {-| Provides the Set312-7 color.
 -}
 set312_7 : Color
 set312_7 =
-    rgb 252 205 229
+    rgb255 252 205 229
 
 
 {-| Provides the Set312-8 color.
 -}
 set312_8 : Color
 set312_8 =
-    rgb 217 217 217
+    rgb255 217 217 217
 
 
 {-| Provides the Set312-9 color.
 -}
 set312_9 : Color
 set312_9 =
-    rgb 188 128 189
+    rgb255 188 128 189
 
 
 {-| Provides the Set312-10 color.
 -}
 set312_10 : Color
 set312_10 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the Set312-11 color.
 -}
 set312_11 : Color
 set312_11 =
-    rgb 255 237 111
+    rgb255 255 237 111
 
 
 {-| Provides the Dark23 color scheme.
 -}
 dark23 : List Color
 dark23 =
-    [ rgb 27 158 119, rgb 217 95 2, rgb 117 112 179 ]
+    [ rgb255 27 158 119, rgb255 217 95 2, rgb255 117 112 179 ]
 
 
 {-| Provides the Dark23-0 color.
 -}
 dark23_0 : Color
 dark23_0 =
-    rgb 27 158 119
+    rgb255 27 158 119
 
 
 {-| Provides the Dark23-1 color.
 -}
 dark23_1 : Color
 dark23_1 =
-    rgb 217 95 2
+    rgb255 217 95 2
 
 
 {-| Provides the Dark23-2 color.
 -}
 dark23_2 : Color
 dark23_2 =
-    rgb 117 112 179
+    rgb255 117 112 179
 
 
 {-| Provides the Dark24 color scheme.
 -}
 dark24 : List Color
 dark24 =
-    [ rgb 27 158 119, rgb 217 95 2, rgb 117 112 179, rgb 231 41 138 ]
+    [ rgb255 27 158 119, rgb255 217 95 2, rgb255 117 112 179, rgb255 231 41 138 ]
 
 
 {-| Provides the Dark24-0 color.
 -}
 dark24_0 : Color
 dark24_0 =
-    rgb 27 158 119
+    rgb255 27 158 119
 
 
 {-| Provides the Dark24-1 color.
 -}
 dark24_1 : Color
 dark24_1 =
-    rgb 217 95 2
+    rgb255 217 95 2
 
 
 {-| Provides the Dark24-2 color.
 -}
 dark24_2 : Color
 dark24_2 =
-    rgb 117 112 179
+    rgb255 117 112 179
 
 
 {-| Provides the Dark24-3 color.
 -}
 dark24_3 : Color
 dark24_3 =
-    rgb 231 41 138
+    rgb255 231 41 138
 
 
 {-| Provides the Dark25 color scheme.
 -}
 dark25 : List Color
 dark25 =
-    [ rgb 27 158 119, rgb 217 95 2, rgb 117 112 179, rgb 231 41 138, rgb 102 166 30 ]
+    [ rgb255 27 158 119, rgb255 217 95 2, rgb255 117 112 179, rgb255 231 41 138, rgb255 102 166 30 ]
 
 
 {-| Provides the Dark25-0 color.
 -}
 dark25_0 : Color
 dark25_0 =
-    rgb 27 158 119
+    rgb255 27 158 119
 
 
 {-| Provides the Dark25-1 color.
 -}
 dark25_1 : Color
 dark25_1 =
-    rgb 217 95 2
+    rgb255 217 95 2
 
 
 {-| Provides the Dark25-2 color.
 -}
 dark25_2 : Color
 dark25_2 =
-    rgb 117 112 179
+    rgb255 117 112 179
 
 
 {-| Provides the Dark25-3 color.
 -}
 dark25_3 : Color
 dark25_3 =
-    rgb 231 41 138
+    rgb255 231 41 138
 
 
 {-| Provides the Dark25-4 color.
 -}
 dark25_4 : Color
 dark25_4 =
-    rgb 102 166 30
+    rgb255 102 166 30
 
 
 {-| Provides the Dark26 color scheme.
 -}
 dark26 : List Color
 dark26 =
-    [ rgb 27 158 119, rgb 217 95 2, rgb 117 112 179, rgb 231 41 138, rgb 102 166 30, rgb 230 171 2 ]
+    [ rgb255 27 158 119, rgb255 217 95 2, rgb255 117 112 179, rgb255 231 41 138, rgb255 102 166 30, rgb255 230 171 2 ]
 
 
 {-| Provides the Dark26-0 color.
 -}
 dark26_0 : Color
 dark26_0 =
-    rgb 27 158 119
+    rgb255 27 158 119
 
 
 {-| Provides the Dark26-1 color.
 -}
 dark26_1 : Color
 dark26_1 =
-    rgb 217 95 2
+    rgb255 217 95 2
 
 
 {-| Provides the Dark26-2 color.
 -}
 dark26_2 : Color
 dark26_2 =
-    rgb 117 112 179
+    rgb255 117 112 179
 
 
 {-| Provides the Dark26-3 color.
 -}
 dark26_3 : Color
 dark26_3 =
-    rgb 231 41 138
+    rgb255 231 41 138
 
 
 {-| Provides the Dark26-4 color.
 -}
 dark26_4 : Color
 dark26_4 =
-    rgb 102 166 30
+    rgb255 102 166 30
 
 
 {-| Provides the Dark26-5 color.
 -}
 dark26_5 : Color
 dark26_5 =
-    rgb 230 171 2
+    rgb255 230 171 2
 
 
 {-| Provides the Dark27 color scheme.
 -}
 dark27 : List Color
 dark27 =
-    [ rgb 27 158 119, rgb 217 95 2, rgb 117 112 179, rgb 231 41 138, rgb 102 166 30, rgb 230 171 2, rgb 166 118 29 ]
+    [ rgb255 27 158 119, rgb255 217 95 2, rgb255 117 112 179, rgb255 231 41 138, rgb255 102 166 30, rgb255 230 171 2, rgb255 166 118 29 ]
 
 
 {-| Provides the Dark27-0 color.
 -}
 dark27_0 : Color
 dark27_0 =
-    rgb 27 158 119
+    rgb255 27 158 119
 
 
 {-| Provides the Dark27-1 color.
 -}
 dark27_1 : Color
 dark27_1 =
-    rgb 217 95 2
+    rgb255 217 95 2
 
 
 {-| Provides the Dark27-2 color.
 -}
 dark27_2 : Color
 dark27_2 =
-    rgb 117 112 179
+    rgb255 117 112 179
 
 
 {-| Provides the Dark27-3 color.
 -}
 dark27_3 : Color
 dark27_3 =
-    rgb 231 41 138
+    rgb255 231 41 138
 
 
 {-| Provides the Dark27-4 color.
 -}
 dark27_4 : Color
 dark27_4 =
-    rgb 102 166 30
+    rgb255 102 166 30
 
 
 {-| Provides the Dark27-5 color.
 -}
 dark27_5 : Color
 dark27_5 =
-    rgb 230 171 2
+    rgb255 230 171 2
 
 
 {-| Provides the Dark27-6 color.
 -}
 dark27_6 : Color
 dark27_6 =
-    rgb 166 118 29
+    rgb255 166 118 29
 
 
 {-| Provides the Dark28 color scheme.
 -}
 dark28 : List Color
 dark28 =
-    [ rgb 27 158 119, rgb 217 95 2, rgb 117 112 179, rgb 231 41 138, rgb 102 166 30, rgb 230 171 2, rgb 166 118 29, rgb 102 102 102 ]
+    [ rgb255 27 158 119, rgb255 217 95 2, rgb255 117 112 179, rgb255 231 41 138, rgb255 102 166 30, rgb255 230 171 2, rgb255 166 118 29, rgb255 102 102 102 ]
 
 
 {-| Provides the Dark28-0 color.
 -}
 dark28_0 : Color
 dark28_0 =
-    rgb 27 158 119
+    rgb255 27 158 119
 
 
 {-| Provides the Dark28-1 color.
 -}
 dark28_1 : Color
 dark28_1 =
-    rgb 217 95 2
+    rgb255 217 95 2
 
 
 {-| Provides the Dark28-2 color.
 -}
 dark28_2 : Color
 dark28_2 =
-    rgb 117 112 179
+    rgb255 117 112 179
 
 
 {-| Provides the Dark28-3 color.
 -}
 dark28_3 : Color
 dark28_3 =
-    rgb 231 41 138
+    rgb255 231 41 138
 
 
 {-| Provides the Dark28-4 color.
 -}
 dark28_4 : Color
 dark28_4 =
-    rgb 102 166 30
+    rgb255 102 166 30
 
 
 {-| Provides the Dark28-5 color.
 -}
 dark28_5 : Color
 dark28_5 =
-    rgb 230 171 2
+    rgb255 230 171 2
 
 
 {-| Provides the Dark28-6 color.
 -}
 dark28_6 : Color
 dark28_6 =
-    rgb 166 118 29
+    rgb255 166 118 29
 
 
 {-| Provides the Dark28-7 color.
 -}
 dark28_7 : Color
 dark28_7 =
-    rgb 102 102 102
+    rgb255 102 102 102
 
 
 {-| Provides the Paired3 color scheme.
 -}
 paired3 : List Color
 paired3 =
-    [ rgb 166 206 227, rgb 31 120 180, rgb 178 223 138 ]
+    [ rgb255 166 206 227, rgb255 31 120 180, rgb255 178 223 138 ]
 
 
 {-| Provides the Paired3-0 color.
 -}
 paired3_0 : Color
 paired3_0 =
-    rgb 166 206 227
+    rgb255 166 206 227
 
 
 {-| Provides the Paired3-1 color.
 -}
 paired3_1 : Color
 paired3_1 =
-    rgb 31 120 180
+    rgb255 31 120 180
 
 
 {-| Provides the Paired3-2 color.
 -}
 paired3_2 : Color
 paired3_2 =
-    rgb 178 223 138
+    rgb255 178 223 138
 
 
 {-| Provides the Paired4 color scheme.
 -}
 paired4 : List Color
 paired4 =
-    [ rgb 166 206 227, rgb 31 120 180, rgb 178 223 138, rgb 51 160 44 ]
+    [ rgb255 166 206 227, rgb255 31 120 180, rgb255 178 223 138, rgb255 51 160 44 ]
 
 
 {-| Provides the Paired4-0 color.
 -}
 paired4_0 : Color
 paired4_0 =
-    rgb 166 206 227
+    rgb255 166 206 227
 
 
 {-| Provides the Paired4-1 color.
 -}
 paired4_1 : Color
 paired4_1 =
-    rgb 31 120 180
+    rgb255 31 120 180
 
 
 {-| Provides the Paired4-2 color.
 -}
 paired4_2 : Color
 paired4_2 =
-    rgb 178 223 138
+    rgb255 178 223 138
 
 
 {-| Provides the Paired4-3 color.
 -}
 paired4_3 : Color
 paired4_3 =
-    rgb 51 160 44
+    rgb255 51 160 44
 
 
 {-| Provides the Paired5 color scheme.
 -}
 paired5 : List Color
 paired5 =
-    [ rgb 166 206 227, rgb 31 120 180, rgb 178 223 138, rgb 51 160 44, rgb 251 154 153 ]
+    [ rgb255 166 206 227, rgb255 31 120 180, rgb255 178 223 138, rgb255 51 160 44, rgb255 251 154 153 ]
 
 
 {-| Provides the Paired5-0 color.
 -}
 paired5_0 : Color
 paired5_0 =
-    rgb 166 206 227
+    rgb255 166 206 227
 
 
 {-| Provides the Paired5-1 color.
 -}
 paired5_1 : Color
 paired5_1 =
-    rgb 31 120 180
+    rgb255 31 120 180
 
 
 {-| Provides the Paired5-2 color.
 -}
 paired5_2 : Color
 paired5_2 =
-    rgb 178 223 138
+    rgb255 178 223 138
 
 
 {-| Provides the Paired5-3 color.
 -}
 paired5_3 : Color
 paired5_3 =
-    rgb 51 160 44
+    rgb255 51 160 44
 
 
 {-| Provides the Paired5-4 color.
 -}
 paired5_4 : Color
 paired5_4 =
-    rgb 251 154 153
+    rgb255 251 154 153
 
 
 {-| Provides the Paired6 color scheme.
 -}
 paired6 : List Color
 paired6 =
-    [ rgb 166 206 227, rgb 31 120 180, rgb 178 223 138, rgb 51 160 44, rgb 251 154 153, rgb 227 26 28 ]
+    [ rgb255 166 206 227, rgb255 31 120 180, rgb255 178 223 138, rgb255 51 160 44, rgb255 251 154 153, rgb255 227 26 28 ]
 
 
 {-| Provides the Paired6-0 color.
 -}
 paired6_0 : Color
 paired6_0 =
-    rgb 166 206 227
+    rgb255 166 206 227
 
 
 {-| Provides the Paired6-1 color.
 -}
 paired6_1 : Color
 paired6_1 =
-    rgb 31 120 180
+    rgb255 31 120 180
 
 
 {-| Provides the Paired6-2 color.
 -}
 paired6_2 : Color
 paired6_2 =
-    rgb 178 223 138
+    rgb255 178 223 138
 
 
 {-| Provides the Paired6-3 color.
 -}
 paired6_3 : Color
 paired6_3 =
-    rgb 51 160 44
+    rgb255 51 160 44
 
 
 {-| Provides the Paired6-4 color.
 -}
 paired6_4 : Color
 paired6_4 =
-    rgb 251 154 153
+    rgb255 251 154 153
 
 
 {-| Provides the Paired6-5 color.
 -}
 paired6_5 : Color
 paired6_5 =
-    rgb 227 26 28
+    rgb255 227 26 28
 
 
 {-| Provides the Paired7 color scheme.
 -}
 paired7 : List Color
 paired7 =
-    [ rgb 166 206 227, rgb 31 120 180, rgb 178 223 138, rgb 51 160 44, rgb 251 154 153, rgb 227 26 28, rgb 253 191 111 ]
+    [ rgb255 166 206 227, rgb255 31 120 180, rgb255 178 223 138, rgb255 51 160 44, rgb255 251 154 153, rgb255 227 26 28, rgb255 253 191 111 ]
 
 
 {-| Provides the Paired7-0 color.
 -}
 paired7_0 : Color
 paired7_0 =
-    rgb 166 206 227
+    rgb255 166 206 227
 
 
 {-| Provides the Paired7-1 color.
 -}
 paired7_1 : Color
 paired7_1 =
-    rgb 31 120 180
+    rgb255 31 120 180
 
 
 {-| Provides the Paired7-2 color.
 -}
 paired7_2 : Color
 paired7_2 =
-    rgb 178 223 138
+    rgb255 178 223 138
 
 
 {-| Provides the Paired7-3 color.
 -}
 paired7_3 : Color
 paired7_3 =
-    rgb 51 160 44
+    rgb255 51 160 44
 
 
 {-| Provides the Paired7-4 color.
 -}
 paired7_4 : Color
 paired7_4 =
-    rgb 251 154 153
+    rgb255 251 154 153
 
 
 {-| Provides the Paired7-5 color.
 -}
 paired7_5 : Color
 paired7_5 =
-    rgb 227 26 28
+    rgb255 227 26 28
 
 
 {-| Provides the Paired7-6 color.
 -}
 paired7_6 : Color
 paired7_6 =
-    rgb 253 191 111
+    rgb255 253 191 111
 
 
 {-| Provides the Paired8 color scheme.
 -}
 paired8 : List Color
 paired8 =
-    [ rgb 166 206 227, rgb 31 120 180, rgb 178 223 138, rgb 51 160 44, rgb 251 154 153, rgb 227 26 28, rgb 253 191 111, rgb 255 127 0 ]
+    [ rgb255 166 206 227, rgb255 31 120 180, rgb255 178 223 138, rgb255 51 160 44, rgb255 251 154 153, rgb255 227 26 28, rgb255 253 191 111, rgb255 255 127 0 ]
 
 
 {-| Provides the Paired8-0 color.
 -}
 paired8_0 : Color
 paired8_0 =
-    rgb 166 206 227
+    rgb255 166 206 227
 
 
 {-| Provides the Paired8-1 color.
 -}
 paired8_1 : Color
 paired8_1 =
-    rgb 31 120 180
+    rgb255 31 120 180
 
 
 {-| Provides the Paired8-2 color.
 -}
 paired8_2 : Color
 paired8_2 =
-    rgb 178 223 138
+    rgb255 178 223 138
 
 
 {-| Provides the Paired8-3 color.
 -}
 paired8_3 : Color
 paired8_3 =
-    rgb 51 160 44
+    rgb255 51 160 44
 
 
 {-| Provides the Paired8-4 color.
 -}
 paired8_4 : Color
 paired8_4 =
-    rgb 251 154 153
+    rgb255 251 154 153
 
 
 {-| Provides the Paired8-5 color.
 -}
 paired8_5 : Color
 paired8_5 =
-    rgb 227 26 28
+    rgb255 227 26 28
 
 
 {-| Provides the Paired8-6 color.
 -}
 paired8_6 : Color
 paired8_6 =
-    rgb 253 191 111
+    rgb255 253 191 111
 
 
 {-| Provides the Paired8-7 color.
 -}
 paired8_7 : Color
 paired8_7 =
-    rgb 255 127 0
+    rgb255 255 127 0
 
 
 {-| Provides the Paired9 color scheme.
 -}
 paired9 : List Color
 paired9 =
-    [ rgb 166 206 227, rgb 31 120 180, rgb 178 223 138, rgb 51 160 44, rgb 251 154 153, rgb 227 26 28, rgb 253 191 111, rgb 255 127 0, rgb 202 178 214 ]
+    [ rgb255 166 206 227, rgb255 31 120 180, rgb255 178 223 138, rgb255 51 160 44, rgb255 251 154 153, rgb255 227 26 28, rgb255 253 191 111, rgb255 255 127 0, rgb255 202 178 214 ]
 
 
 {-| Provides the Paired9-0 color.
 -}
 paired9_0 : Color
 paired9_0 =
-    rgb 166 206 227
+    rgb255 166 206 227
 
 
 {-| Provides the Paired9-1 color.
 -}
 paired9_1 : Color
 paired9_1 =
-    rgb 31 120 180
+    rgb255 31 120 180
 
 
 {-| Provides the Paired9-2 color.
 -}
 paired9_2 : Color
 paired9_2 =
-    rgb 178 223 138
+    rgb255 178 223 138
 
 
 {-| Provides the Paired9-3 color.
 -}
 paired9_3 : Color
 paired9_3 =
-    rgb 51 160 44
+    rgb255 51 160 44
 
 
 {-| Provides the Paired9-4 color.
 -}
 paired9_4 : Color
 paired9_4 =
-    rgb 251 154 153
+    rgb255 251 154 153
 
 
 {-| Provides the Paired9-5 color.
 -}
 paired9_5 : Color
 paired9_5 =
-    rgb 227 26 28
+    rgb255 227 26 28
 
 
 {-| Provides the Paired9-6 color.
 -}
 paired9_6 : Color
 paired9_6 =
-    rgb 253 191 111
+    rgb255 253 191 111
 
 
 {-| Provides the Paired9-7 color.
 -}
 paired9_7 : Color
 paired9_7 =
-    rgb 255 127 0
+    rgb255 255 127 0
 
 
 {-| Provides the Paired9-8 color.
 -}
 paired9_8 : Color
 paired9_8 =
-    rgb 202 178 214
+    rgb255 202 178 214
 
 
 {-| Provides the Paired10 color scheme.
 -}
 paired10 : List Color
 paired10 =
-    [ rgb 166 206 227, rgb 31 120 180, rgb 178 223 138, rgb 51 160 44, rgb 251 154 153, rgb 227 26 28, rgb 253 191 111, rgb 255 127 0, rgb 202 178 214, rgb 106 61 154 ]
+    [ rgb255 166 206 227, rgb255 31 120 180, rgb255 178 223 138, rgb255 51 160 44, rgb255 251 154 153, rgb255 227 26 28, rgb255 253 191 111, rgb255 255 127 0, rgb255 202 178 214, rgb255 106 61 154 ]
 
 
 {-| Provides the Paired10-0 color.
 -}
 paired10_0 : Color
 paired10_0 =
-    rgb 166 206 227
+    rgb255 166 206 227
 
 
 {-| Provides the Paired10-1 color.
 -}
 paired10_1 : Color
 paired10_1 =
-    rgb 31 120 180
+    rgb255 31 120 180
 
 
 {-| Provides the Paired10-2 color.
 -}
 paired10_2 : Color
 paired10_2 =
-    rgb 178 223 138
+    rgb255 178 223 138
 
 
 {-| Provides the Paired10-3 color.
 -}
 paired10_3 : Color
 paired10_3 =
-    rgb 51 160 44
+    rgb255 51 160 44
 
 
 {-| Provides the Paired10-4 color.
 -}
 paired10_4 : Color
 paired10_4 =
-    rgb 251 154 153
+    rgb255 251 154 153
 
 
 {-| Provides the Paired10-5 color.
 -}
 paired10_5 : Color
 paired10_5 =
-    rgb 227 26 28
+    rgb255 227 26 28
 
 
 {-| Provides the Paired10-6 color.
 -}
 paired10_6 : Color
 paired10_6 =
-    rgb 253 191 111
+    rgb255 253 191 111
 
 
 {-| Provides the Paired10-7 color.
 -}
 paired10_7 : Color
 paired10_7 =
-    rgb 255 127 0
+    rgb255 255 127 0
 
 
 {-| Provides the Paired10-8 color.
 -}
 paired10_8 : Color
 paired10_8 =
-    rgb 202 178 214
+    rgb255 202 178 214
 
 
 {-| Provides the Paired10-9 color.
 -}
 paired10_9 : Color
 paired10_9 =
-    rgb 106 61 154
+    rgb255 106 61 154
 
 
 {-| Provides the Paired11 color scheme.
 -}
 paired11 : List Color
 paired11 =
-    [ rgb 166 206 227, rgb 31 120 180, rgb 178 223 138, rgb 51 160 44, rgb 251 154 153, rgb 227 26 28, rgb 253 191 111, rgb 255 127 0, rgb 202 178 214, rgb 106 61 154, rgb 255 255 153 ]
+    [ rgb255 166 206 227, rgb255 31 120 180, rgb255 178 223 138, rgb255 51 160 44, rgb255 251 154 153, rgb255 227 26 28, rgb255 253 191 111, rgb255 255 127 0, rgb255 202 178 214, rgb255 106 61 154, rgb255 255 255 153 ]
 
 
 {-| Provides the Paired11-0 color.
 -}
 paired11_0 : Color
 paired11_0 =
-    rgb 166 206 227
+    rgb255 166 206 227
 
 
 {-| Provides the Paired11-1 color.
 -}
 paired11_1 : Color
 paired11_1 =
-    rgb 31 120 180
+    rgb255 31 120 180
 
 
 {-| Provides the Paired11-2 color.
 -}
 paired11_2 : Color
 paired11_2 =
-    rgb 178 223 138
+    rgb255 178 223 138
 
 
 {-| Provides the Paired11-3 color.
 -}
 paired11_3 : Color
 paired11_3 =
-    rgb 51 160 44
+    rgb255 51 160 44
 
 
 {-| Provides the Paired11-4 color.
 -}
 paired11_4 : Color
 paired11_4 =
-    rgb 251 154 153
+    rgb255 251 154 153
 
 
 {-| Provides the Paired11-5 color.
 -}
 paired11_5 : Color
 paired11_5 =
-    rgb 227 26 28
+    rgb255 227 26 28
 
 
 {-| Provides the Paired11-6 color.
 -}
 paired11_6 : Color
 paired11_6 =
-    rgb 253 191 111
+    rgb255 253 191 111
 
 
 {-| Provides the Paired11-7 color.
 -}
 paired11_7 : Color
 paired11_7 =
-    rgb 255 127 0
+    rgb255 255 127 0
 
 
 {-| Provides the Paired11-8 color.
 -}
 paired11_8 : Color
 paired11_8 =
-    rgb 202 178 214
+    rgb255 202 178 214
 
 
 {-| Provides the Paired11-9 color.
 -}
 paired11_9 : Color
 paired11_9 =
-    rgb 106 61 154
+    rgb255 106 61 154
 
 
 {-| Provides the Paired11-10 color.
 -}
 paired11_10 : Color
 paired11_10 =
-    rgb 255 255 153
+    rgb255 255 255 153
 
 
 {-| Provides the Paired12 color scheme.
 -}
 paired12 : List Color
 paired12 =
-    [ rgb 166 206 227, rgb 31 120 180, rgb 178 223 138, rgb 51 160 44, rgb 251 154 153, rgb 227 26 28, rgb 253 191 111, rgb 255 127 0, rgb 202 178 214, rgb 106 61 154, rgb 255 255 153, rgb 177 89 40 ]
+    [ rgb255 166 206 227, rgb255 31 120 180, rgb255 178 223 138, rgb255 51 160 44, rgb255 251 154 153, rgb255 227 26 28, rgb255 253 191 111, rgb255 255 127 0, rgb255 202 178 214, rgb255 106 61 154, rgb255 255 255 153, rgb255 177 89 40 ]
 
 
 {-| Provides the Paired12-0 color.
 -}
 paired12_0 : Color
 paired12_0 =
-    rgb 166 206 227
+    rgb255 166 206 227
 
 
 {-| Provides the Paired12-1 color.
 -}
 paired12_1 : Color
 paired12_1 =
-    rgb 31 120 180
+    rgb255 31 120 180
 
 
 {-| Provides the Paired12-2 color.
 -}
 paired12_2 : Color
 paired12_2 =
-    rgb 178 223 138
+    rgb255 178 223 138
 
 
 {-| Provides the Paired12-3 color.
 -}
 paired12_3 : Color
 paired12_3 =
-    rgb 51 160 44
+    rgb255 51 160 44
 
 
 {-| Provides the Paired12-4 color.
 -}
 paired12_4 : Color
 paired12_4 =
-    rgb 251 154 153
+    rgb255 251 154 153
 
 
 {-| Provides the Paired12-5 color.
 -}
 paired12_5 : Color
 paired12_5 =
-    rgb 227 26 28
+    rgb255 227 26 28
 
 
 {-| Provides the Paired12-6 color.
 -}
 paired12_6 : Color
 paired12_6 =
-    rgb 253 191 111
+    rgb255 253 191 111
 
 
 {-| Provides the Paired12-7 color.
 -}
 paired12_7 : Color
 paired12_7 =
-    rgb 255 127 0
+    rgb255 255 127 0
 
 
 {-| Provides the Paired12-8 color.
 -}
 paired12_8 : Color
 paired12_8 =
-    rgb 202 178 214
+    rgb255 202 178 214
 
 
 {-| Provides the Paired12-9 color.
 -}
 paired12_9 : Color
 paired12_9 =
-    rgb 106 61 154
+    rgb255 106 61 154
 
 
 {-| Provides the Paired12-10 color.
 -}
 paired12_10 : Color
 paired12_10 =
-    rgb 255 255 153
+    rgb255 255 255 153
 
 
 {-| Provides the Paired12-11 color.
 -}
 paired12_11 : Color
 paired12_11 =
-    rgb 177 89 40
+    rgb255 177 89 40
 
 
 {-| Provides the Pastel23 color scheme.
 -}
 pastel23 : List Color
 pastel23 =
-    [ rgb 179 226 205, rgb 253 205 172, rgb 203 213 232 ]
+    [ rgb255 179 226 205, rgb255 253 205 172, rgb255 203 213 232 ]
 
 
 {-| Provides the Pastel23-0 color.
 -}
 pastel23_0 : Color
 pastel23_0 =
-    rgb 179 226 205
+    rgb255 179 226 205
 
 
 {-| Provides the Pastel23-1 color.
 -}
 pastel23_1 : Color
 pastel23_1 =
-    rgb 253 205 172
+    rgb255 253 205 172
 
 
 {-| Provides the Pastel23-2 color.
 -}
 pastel23_2 : Color
 pastel23_2 =
-    rgb 203 213 232
+    rgb255 203 213 232
 
 
 {-| Provides the Pastel24 color scheme.
 -}
 pastel24 : List Color
 pastel24 =
-    [ rgb 179 226 205, rgb 253 205 172, rgb 203 213 232, rgb 244 202 228 ]
+    [ rgb255 179 226 205, rgb255 253 205 172, rgb255 203 213 232, rgb255 244 202 228 ]
 
 
 {-| Provides the Pastel24-0 color.
 -}
 pastel24_0 : Color
 pastel24_0 =
-    rgb 179 226 205
+    rgb255 179 226 205
 
 
 {-| Provides the Pastel24-1 color.
 -}
 pastel24_1 : Color
 pastel24_1 =
-    rgb 253 205 172
+    rgb255 253 205 172
 
 
 {-| Provides the Pastel24-2 color.
 -}
 pastel24_2 : Color
 pastel24_2 =
-    rgb 203 213 232
+    rgb255 203 213 232
 
 
 {-| Provides the Pastel24-3 color.
 -}
 pastel24_3 : Color
 pastel24_3 =
-    rgb 244 202 228
+    rgb255 244 202 228
 
 
 {-| Provides the Pastel25 color scheme.
 -}
 pastel25 : List Color
 pastel25 =
-    [ rgb 179 226 205, rgb 253 205 172, rgb 203 213 232, rgb 244 202 228, rgb 230 245 201 ]
+    [ rgb255 179 226 205, rgb255 253 205 172, rgb255 203 213 232, rgb255 244 202 228, rgb255 230 245 201 ]
 
 
 {-| Provides the Pastel25-0 color.
 -}
 pastel25_0 : Color
 pastel25_0 =
-    rgb 179 226 205
+    rgb255 179 226 205
 
 
 {-| Provides the Pastel25-1 color.
 -}
 pastel25_1 : Color
 pastel25_1 =
-    rgb 253 205 172
+    rgb255 253 205 172
 
 
 {-| Provides the Pastel25-2 color.
 -}
 pastel25_2 : Color
 pastel25_2 =
-    rgb 203 213 232
+    rgb255 203 213 232
 
 
 {-| Provides the Pastel25-3 color.
 -}
 pastel25_3 : Color
 pastel25_3 =
-    rgb 244 202 228
+    rgb255 244 202 228
 
 
 {-| Provides the Pastel25-4 color.
 -}
 pastel25_4 : Color
 pastel25_4 =
-    rgb 230 245 201
+    rgb255 230 245 201
 
 
 {-| Provides the Pastel26 color scheme.
 -}
 pastel26 : List Color
 pastel26 =
-    [ rgb 179 226 205, rgb 253 205 172, rgb 203 213 232, rgb 244 202 228, rgb 230 245 201, rgb 255 242 174 ]
+    [ rgb255 179 226 205, rgb255 253 205 172, rgb255 203 213 232, rgb255 244 202 228, rgb255 230 245 201, rgb255 255 242 174 ]
 
 
 {-| Provides the Pastel26-0 color.
 -}
 pastel26_0 : Color
 pastel26_0 =
-    rgb 179 226 205
+    rgb255 179 226 205
 
 
 {-| Provides the Pastel26-1 color.
 -}
 pastel26_1 : Color
 pastel26_1 =
-    rgb 253 205 172
+    rgb255 253 205 172
 
 
 {-| Provides the Pastel26-2 color.
 -}
 pastel26_2 : Color
 pastel26_2 =
-    rgb 203 213 232
+    rgb255 203 213 232
 
 
 {-| Provides the Pastel26-3 color.
 -}
 pastel26_3 : Color
 pastel26_3 =
-    rgb 244 202 228
+    rgb255 244 202 228
 
 
 {-| Provides the Pastel26-4 color.
 -}
 pastel26_4 : Color
 pastel26_4 =
-    rgb 230 245 201
+    rgb255 230 245 201
 
 
 {-| Provides the Pastel26-5 color.
 -}
 pastel26_5 : Color
 pastel26_5 =
-    rgb 255 242 174
+    rgb255 255 242 174
 
 
 {-| Provides the Pastel27 color scheme.
 -}
 pastel27 : List Color
 pastel27 =
-    [ rgb 179 226 205, rgb 253 205 172, rgb 203 213 232, rgb 244 202 228, rgb 230 245 201, rgb 255 242 174, rgb 241 226 204 ]
+    [ rgb255 179 226 205, rgb255 253 205 172, rgb255 203 213 232, rgb255 244 202 228, rgb255 230 245 201, rgb255 255 242 174, rgb255 241 226 204 ]
 
 
 {-| Provides the Pastel27-0 color.
 -}
 pastel27_0 : Color
 pastel27_0 =
-    rgb 179 226 205
+    rgb255 179 226 205
 
 
 {-| Provides the Pastel27-1 color.
 -}
 pastel27_1 : Color
 pastel27_1 =
-    rgb 253 205 172
+    rgb255 253 205 172
 
 
 {-| Provides the Pastel27-2 color.
 -}
 pastel27_2 : Color
 pastel27_2 =
-    rgb 203 213 232
+    rgb255 203 213 232
 
 
 {-| Provides the Pastel27-3 color.
 -}
 pastel27_3 : Color
 pastel27_3 =
-    rgb 244 202 228
+    rgb255 244 202 228
 
 
 {-| Provides the Pastel27-4 color.
 -}
 pastel27_4 : Color
 pastel27_4 =
-    rgb 230 245 201
+    rgb255 230 245 201
 
 
 {-| Provides the Pastel27-5 color.
 -}
 pastel27_5 : Color
 pastel27_5 =
-    rgb 255 242 174
+    rgb255 255 242 174
 
 
 {-| Provides the Pastel27-6 color.
 -}
 pastel27_6 : Color
 pastel27_6 =
-    rgb 241 226 204
+    rgb255 241 226 204
 
 
 {-| Provides the Pastel28 color scheme.
 -}
 pastel28 : List Color
 pastel28 =
-    [ rgb 179 226 205, rgb 253 205 172, rgb 203 213 232, rgb 244 202 228, rgb 230 245 201, rgb 255 242 174, rgb 241 226 204, rgb 204 204 204 ]
+    [ rgb255 179 226 205, rgb255 253 205 172, rgb255 203 213 232, rgb255 244 202 228, rgb255 230 245 201, rgb255 255 242 174, rgb255 241 226 204, rgb255 204 204 204 ]
 
 
 {-| Provides the Pastel28-0 color.
 -}
 pastel28_0 : Color
 pastel28_0 =
-    rgb 179 226 205
+    rgb255 179 226 205
 
 
 {-| Provides the Pastel28-1 color.
 -}
 pastel28_1 : Color
 pastel28_1 =
-    rgb 253 205 172
+    rgb255 253 205 172
 
 
 {-| Provides the Pastel28-2 color.
 -}
 pastel28_2 : Color
 pastel28_2 =
-    rgb 203 213 232
+    rgb255 203 213 232
 
 
 {-| Provides the Pastel28-3 color.
 -}
 pastel28_3 : Color
 pastel28_3 =
-    rgb 244 202 228
+    rgb255 244 202 228
 
 
 {-| Provides the Pastel28-4 color.
 -}
 pastel28_4 : Color
 pastel28_4 =
-    rgb 230 245 201
+    rgb255 230 245 201
 
 
 {-| Provides the Pastel28-5 color.
 -}
 pastel28_5 : Color
 pastel28_5 =
-    rgb 255 242 174
+    rgb255 255 242 174
 
 
 {-| Provides the Pastel28-6 color.
 -}
 pastel28_6 : Color
 pastel28_6 =
-    rgb 241 226 204
+    rgb255 241 226 204
 
 
 {-| Provides the Pastel28-7 color.
 -}
 pastel28_7 : Color
 pastel28_7 =
-    rgb 204 204 204
+    rgb255 204 204 204
 
 
 {-| Provides the Pastel13 color scheme.
 -}
 pastel13 : List Color
 pastel13 =
-    [ rgb 251 180 174, rgb 179 205 227, rgb 204 235 197 ]
+    [ rgb255 251 180 174, rgb255 179 205 227, rgb255 204 235 197 ]
 
 
 {-| Provides the Pastel13-0 color.
 -}
 pastel13_0 : Color
 pastel13_0 =
-    rgb 251 180 174
+    rgb255 251 180 174
 
 
 {-| Provides the Pastel13-1 color.
 -}
 pastel13_1 : Color
 pastel13_1 =
-    rgb 179 205 227
+    rgb255 179 205 227
 
 
 {-| Provides the Pastel13-2 color.
 -}
 pastel13_2 : Color
 pastel13_2 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the Pastel14 color scheme.
 -}
 pastel14 : List Color
 pastel14 =
-    [ rgb 251 180 174, rgb 179 205 227, rgb 204 235 197, rgb 222 203 228 ]
+    [ rgb255 251 180 174, rgb255 179 205 227, rgb255 204 235 197, rgb255 222 203 228 ]
 
 
 {-| Provides the Pastel14-0 color.
 -}
 pastel14_0 : Color
 pastel14_0 =
-    rgb 251 180 174
+    rgb255 251 180 174
 
 
 {-| Provides the Pastel14-1 color.
 -}
 pastel14_1 : Color
 pastel14_1 =
-    rgb 179 205 227
+    rgb255 179 205 227
 
 
 {-| Provides the Pastel14-2 color.
 -}
 pastel14_2 : Color
 pastel14_2 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the Pastel14-3 color.
 -}
 pastel14_3 : Color
 pastel14_3 =
-    rgb 222 203 228
+    rgb255 222 203 228
 
 
 {-| Provides the Pastel15 color scheme.
 -}
 pastel15 : List Color
 pastel15 =
-    [ rgb 251 180 174, rgb 179 205 227, rgb 204 235 197, rgb 222 203 228, rgb 254 217 166 ]
+    [ rgb255 251 180 174, rgb255 179 205 227, rgb255 204 235 197, rgb255 222 203 228, rgb255 254 217 166 ]
 
 
 {-| Provides the Pastel15-0 color.
 -}
 pastel15_0 : Color
 pastel15_0 =
-    rgb 251 180 174
+    rgb255 251 180 174
 
 
 {-| Provides the Pastel15-1 color.
 -}
 pastel15_1 : Color
 pastel15_1 =
-    rgb 179 205 227
+    rgb255 179 205 227
 
 
 {-| Provides the Pastel15-2 color.
 -}
 pastel15_2 : Color
 pastel15_2 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the Pastel15-3 color.
 -}
 pastel15_3 : Color
 pastel15_3 =
-    rgb 222 203 228
+    rgb255 222 203 228
 
 
 {-| Provides the Pastel15-4 color.
 -}
 pastel15_4 : Color
 pastel15_4 =
-    rgb 254 217 166
+    rgb255 254 217 166
 
 
 {-| Provides the Pastel16 color scheme.
 -}
 pastel16 : List Color
 pastel16 =
-    [ rgb 251 180 174, rgb 179 205 227, rgb 204 235 197, rgb 222 203 228, rgb 254 217 166, rgb 255 255 204 ]
+    [ rgb255 251 180 174, rgb255 179 205 227, rgb255 204 235 197, rgb255 222 203 228, rgb255 254 217 166, rgb255 255 255 204 ]
 
 
 {-| Provides the Pastel16-0 color.
 -}
 pastel16_0 : Color
 pastel16_0 =
-    rgb 251 180 174
+    rgb255 251 180 174
 
 
 {-| Provides the Pastel16-1 color.
 -}
 pastel16_1 : Color
 pastel16_1 =
-    rgb 179 205 227
+    rgb255 179 205 227
 
 
 {-| Provides the Pastel16-2 color.
 -}
 pastel16_2 : Color
 pastel16_2 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the Pastel16-3 color.
 -}
 pastel16_3 : Color
 pastel16_3 =
-    rgb 222 203 228
+    rgb255 222 203 228
 
 
 {-| Provides the Pastel16-4 color.
 -}
 pastel16_4 : Color
 pastel16_4 =
-    rgb 254 217 166
+    rgb255 254 217 166
 
 
 {-| Provides the Pastel16-5 color.
 -}
 pastel16_5 : Color
 pastel16_5 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the Pastel17 color scheme.
 -}
 pastel17 : List Color
 pastel17 =
-    [ rgb 251 180 174, rgb 179 205 227, rgb 204 235 197, rgb 222 203 228, rgb 254 217 166, rgb 255 255 204, rgb 229 216 189 ]
+    [ rgb255 251 180 174, rgb255 179 205 227, rgb255 204 235 197, rgb255 222 203 228, rgb255 254 217 166, rgb255 255 255 204, rgb255 229 216 189 ]
 
 
 {-| Provides the Pastel17-0 color.
 -}
 pastel17_0 : Color
 pastel17_0 =
-    rgb 251 180 174
+    rgb255 251 180 174
 
 
 {-| Provides the Pastel17-1 color.
 -}
 pastel17_1 : Color
 pastel17_1 =
-    rgb 179 205 227
+    rgb255 179 205 227
 
 
 {-| Provides the Pastel17-2 color.
 -}
 pastel17_2 : Color
 pastel17_2 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the Pastel17-3 color.
 -}
 pastel17_3 : Color
 pastel17_3 =
-    rgb 222 203 228
+    rgb255 222 203 228
 
 
 {-| Provides the Pastel17-4 color.
 -}
 pastel17_4 : Color
 pastel17_4 =
-    rgb 254 217 166
+    rgb255 254 217 166
 
 
 {-| Provides the Pastel17-5 color.
 -}
 pastel17_5 : Color
 pastel17_5 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the Pastel17-6 color.
 -}
 pastel17_6 : Color
 pastel17_6 =
-    rgb 229 216 189
+    rgb255 229 216 189
 
 
 {-| Provides the Pastel18 color scheme.
 -}
 pastel18 : List Color
 pastel18 =
-    [ rgb 251 180 174, rgb 179 205 227, rgb 204 235 197, rgb 222 203 228, rgb 254 217 166, rgb 255 255 204, rgb 229 216 189, rgb 253 218 236 ]
+    [ rgb255 251 180 174, rgb255 179 205 227, rgb255 204 235 197, rgb255 222 203 228, rgb255 254 217 166, rgb255 255 255 204, rgb255 229 216 189, rgb255 253 218 236 ]
 
 
 {-| Provides the Pastel18-0 color.
 -}
 pastel18_0 : Color
 pastel18_0 =
-    rgb 251 180 174
+    rgb255 251 180 174
 
 
 {-| Provides the Pastel18-1 color.
 -}
 pastel18_1 : Color
 pastel18_1 =
-    rgb 179 205 227
+    rgb255 179 205 227
 
 
 {-| Provides the Pastel18-2 color.
 -}
 pastel18_2 : Color
 pastel18_2 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the Pastel18-3 color.
 -}
 pastel18_3 : Color
 pastel18_3 =
-    rgb 222 203 228
+    rgb255 222 203 228
 
 
 {-| Provides the Pastel18-4 color.
 -}
 pastel18_4 : Color
 pastel18_4 =
-    rgb 254 217 166
+    rgb255 254 217 166
 
 
 {-| Provides the Pastel18-5 color.
 -}
 pastel18_5 : Color
 pastel18_5 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the Pastel18-6 color.
 -}
 pastel18_6 : Color
 pastel18_6 =
-    rgb 229 216 189
+    rgb255 229 216 189
 
 
 {-| Provides the Pastel18-7 color.
 -}
 pastel18_7 : Color
 pastel18_7 =
-    rgb 253 218 236
+    rgb255 253 218 236
 
 
 {-| Provides the Pastel19 color scheme.
 -}
 pastel19 : List Color
 pastel19 =
-    [ rgb 251 180 174, rgb 179 205 227, rgb 204 235 197, rgb 222 203 228, rgb 254 217 166, rgb 255 255 204, rgb 229 216 189, rgb 253 218 236, rgb 242 242 242 ]
+    [ rgb255 251 180 174, rgb255 179 205 227, rgb255 204 235 197, rgb255 222 203 228, rgb255 254 217 166, rgb255 255 255 204, rgb255 229 216 189, rgb255 253 218 236, rgb255 242 242 242 ]
 
 
 {-| Provides the Pastel19-0 color.
 -}
 pastel19_0 : Color
 pastel19_0 =
-    rgb 251 180 174
+    rgb255 251 180 174
 
 
 {-| Provides the Pastel19-1 color.
 -}
 pastel19_1 : Color
 pastel19_1 =
-    rgb 179 205 227
+    rgb255 179 205 227
 
 
 {-| Provides the Pastel19-2 color.
 -}
 pastel19_2 : Color
 pastel19_2 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the Pastel19-3 color.
 -}
 pastel19_3 : Color
 pastel19_3 =
-    rgb 222 203 228
+    rgb255 222 203 228
 
 
 {-| Provides the Pastel19-4 color.
 -}
 pastel19_4 : Color
 pastel19_4 =
-    rgb 254 217 166
+    rgb255 254 217 166
 
 
 {-| Provides the Pastel19-5 color.
 -}
 pastel19_5 : Color
 pastel19_5 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the Pastel19-6 color.
 -}
 pastel19_6 : Color
 pastel19_6 =
-    rgb 229 216 189
+    rgb255 229 216 189
 
 
 {-| Provides the Pastel19-7 color.
 -}
 pastel19_7 : Color
 pastel19_7 =
-    rgb 253 218 236
+    rgb255 253 218 236
 
 
 {-| Provides the Pastel19-8 color.
 -}
 pastel19_8 : Color
 pastel19_8 =
-    rgb 242 242 242
+    rgb255 242 242 242
 
 
 {-| Returns a Set2 color scheme.
@@ -2986,10 +2986,10 @@ set2 n =
             []
 
         1 ->
-            [ rgb 102 194 165 ]
+            [ rgb255 102 194 165 ]
 
         2 ->
-            [ rgb 102 194 165, rgb 252 141 98 ]
+            [ rgb255 102 194 165, rgb255 252 141 98 ]
 
         3 ->
             set23
@@ -3019,10 +3019,10 @@ accent n =
             []
 
         1 ->
-            [ rgb 127 201 127 ]
+            [ rgb255 127 201 127 ]
 
         2 ->
-            [ rgb 127 201 127, rgb 190 174 212 ]
+            [ rgb255 127 201 127, rgb255 190 174 212 ]
 
         3 ->
             accent3
@@ -3052,10 +3052,10 @@ set1 n =
             []
 
         1 ->
-            [ rgb 228 26 28 ]
+            [ rgb255 228 26 28 ]
 
         2 ->
-            [ rgb 228 26 28, rgb 55 126 184 ]
+            [ rgb255 228 26 28, rgb255 55 126 184 ]
 
         3 ->
             set13
@@ -3088,10 +3088,10 @@ set3 n =
             []
 
         1 ->
-            [ rgb 141 211 199 ]
+            [ rgb255 141 211 199 ]
 
         2 ->
-            [ rgb 141 211 199, rgb 255 255 179 ]
+            [ rgb255 141 211 199, rgb255 255 255 179 ]
 
         3 ->
             set33
@@ -3133,10 +3133,10 @@ dark2 n =
             []
 
         1 ->
-            [ rgb 27 158 119 ]
+            [ rgb255 27 158 119 ]
 
         2 ->
-            [ rgb 27 158 119, rgb 217 95 2 ]
+            [ rgb255 27 158 119, rgb255 217 95 2 ]
 
         3 ->
             dark23
@@ -3166,10 +3166,10 @@ paired n =
             []
 
         1 ->
-            [ rgb 166 206 227 ]
+            [ rgb255 166 206 227 ]
 
         2 ->
-            [ rgb 166 206 227, rgb 31 120 180 ]
+            [ rgb255 166 206 227, rgb255 31 120 180 ]
 
         3 ->
             paired3
@@ -3211,10 +3211,10 @@ pastel2 n =
             []
 
         1 ->
-            [ rgb 179 226 205 ]
+            [ rgb255 179 226 205 ]
 
         2 ->
-            [ rgb 179 226 205, rgb 253 205 172 ]
+            [ rgb255 179 226 205, rgb255 253 205 172 ]
 
         3 ->
             pastel23
@@ -3244,10 +3244,10 @@ pastel1 n =
             []
 
         1 ->
-            [ rgb 251 180 174 ]
+            [ rgb255 251 180 174 ]
 
         2 ->
-            [ rgb 251 180 174, rgb 179 205 227 ]
+            [ rgb255 251 180 174, rgb255 179 205 227 ]
 
         3 ->
             pastel13

--- a/src/Colorbrewer/SequentialMH.elm
+++ b/src/Colorbrewer/SequentialMH.elm
@@ -6,4053 +6,4053 @@ module Colorbrewer.SequentialMH exposing (orrd3_0, orrd3_1, orrd3_2, orrd3, orrd
 
 -}
 
-import Color exposing (Color, rgb)
+import Color exposing (Color, rgb255)
 
 
 {-| Provides the OrRd3 color scheme.
 -}
 orrd3 : List Color
 orrd3 =
-    [ rgb 254 232 200, rgb 253 187 132, rgb 227 74 51 ]
+    [ rgb255 254 232 200, rgb255 253 187 132, rgb255 227 74 51 ]
 
 
 {-| Provides the OrRd3-0 color.
 -}
 orrd3_0 : Color
 orrd3_0 =
-    rgb 254 232 200
+    rgb255 254 232 200
 
 
 {-| Provides the OrRd3-1 color.
 -}
 orrd3_1 : Color
 orrd3_1 =
-    rgb 253 187 132
+    rgb255 253 187 132
 
 
 {-| Provides the OrRd3-2 color.
 -}
 orrd3_2 : Color
 orrd3_2 =
-    rgb 227 74 51
+    rgb255 227 74 51
 
 
 {-| Provides the OrRd4 color scheme.
 -}
 orrd4 : List Color
 orrd4 =
-    [ rgb 254 240 217, rgb 253 204 138, rgb 252 141 89, rgb 215 48 31 ]
+    [ rgb255 254 240 217, rgb255 253 204 138, rgb255 252 141 89, rgb255 215 48 31 ]
 
 
 {-| Provides the OrRd4-0 color.
 -}
 orrd4_0 : Color
 orrd4_0 =
-    rgb 254 240 217
+    rgb255 254 240 217
 
 
 {-| Provides the OrRd4-1 color.
 -}
 orrd4_1 : Color
 orrd4_1 =
-    rgb 253 204 138
+    rgb255 253 204 138
 
 
 {-| Provides the OrRd4-2 color.
 -}
 orrd4_2 : Color
 orrd4_2 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the OrRd4-3 color.
 -}
 orrd4_3 : Color
 orrd4_3 =
-    rgb 215 48 31
+    rgb255 215 48 31
 
 
 {-| Provides the OrRd5 color scheme.
 -}
 orrd5 : List Color
 orrd5 =
-    [ rgb 254 240 217, rgb 253 204 138, rgb 252 141 89, rgb 227 74 51, rgb 179 0 0 ]
+    [ rgb255 254 240 217, rgb255 253 204 138, rgb255 252 141 89, rgb255 227 74 51, rgb255 179 0 0 ]
 
 
 {-| Provides the OrRd5-0 color.
 -}
 orrd5_0 : Color
 orrd5_0 =
-    rgb 254 240 217
+    rgb255 254 240 217
 
 
 {-| Provides the OrRd5-1 color.
 -}
 orrd5_1 : Color
 orrd5_1 =
-    rgb 253 204 138
+    rgb255 253 204 138
 
 
 {-| Provides the OrRd5-2 color.
 -}
 orrd5_2 : Color
 orrd5_2 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the OrRd5-3 color.
 -}
 orrd5_3 : Color
 orrd5_3 =
-    rgb 227 74 51
+    rgb255 227 74 51
 
 
 {-| Provides the OrRd5-4 color.
 -}
 orrd5_4 : Color
 orrd5_4 =
-    rgb 179 0 0
+    rgb255 179 0 0
 
 
 {-| Provides the OrRd6 color scheme.
 -}
 orrd6 : List Color
 orrd6 =
-    [ rgb 254 240 217, rgb 253 212 158, rgb 253 187 132, rgb 252 141 89, rgb 227 74 51, rgb 179 0 0 ]
+    [ rgb255 254 240 217, rgb255 253 212 158, rgb255 253 187 132, rgb255 252 141 89, rgb255 227 74 51, rgb255 179 0 0 ]
 
 
 {-| Provides the OrRd6-0 color.
 -}
 orrd6_0 : Color
 orrd6_0 =
-    rgb 254 240 217
+    rgb255 254 240 217
 
 
 {-| Provides the OrRd6-1 color.
 -}
 orrd6_1 : Color
 orrd6_1 =
-    rgb 253 212 158
+    rgb255 253 212 158
 
 
 {-| Provides the OrRd6-2 color.
 -}
 orrd6_2 : Color
 orrd6_2 =
-    rgb 253 187 132
+    rgb255 253 187 132
 
 
 {-| Provides the OrRd6-3 color.
 -}
 orrd6_3 : Color
 orrd6_3 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the OrRd6-4 color.
 -}
 orrd6_4 : Color
 orrd6_4 =
-    rgb 227 74 51
+    rgb255 227 74 51
 
 
 {-| Provides the OrRd6-5 color.
 -}
 orrd6_5 : Color
 orrd6_5 =
-    rgb 179 0 0
+    rgb255 179 0 0
 
 
 {-| Provides the OrRd7 color scheme.
 -}
 orrd7 : List Color
 orrd7 =
-    [ rgb 254 240 217, rgb 253 212 158, rgb 253 187 132, rgb 252 141 89, rgb 239 101 72, rgb 215 48 31, rgb 153 0 0 ]
+    [ rgb255 254 240 217, rgb255 253 212 158, rgb255 253 187 132, rgb255 252 141 89, rgb255 239 101 72, rgb255 215 48 31, rgb255 153 0 0 ]
 
 
 {-| Provides the OrRd7-0 color.
 -}
 orrd7_0 : Color
 orrd7_0 =
-    rgb 254 240 217
+    rgb255 254 240 217
 
 
 {-| Provides the OrRd7-1 color.
 -}
 orrd7_1 : Color
 orrd7_1 =
-    rgb 253 212 158
+    rgb255 253 212 158
 
 
 {-| Provides the OrRd7-2 color.
 -}
 orrd7_2 : Color
 orrd7_2 =
-    rgb 253 187 132
+    rgb255 253 187 132
 
 
 {-| Provides the OrRd7-3 color.
 -}
 orrd7_3 : Color
 orrd7_3 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the OrRd7-4 color.
 -}
 orrd7_4 : Color
 orrd7_4 =
-    rgb 239 101 72
+    rgb255 239 101 72
 
 
 {-| Provides the OrRd7-5 color.
 -}
 orrd7_5 : Color
 orrd7_5 =
-    rgb 215 48 31
+    rgb255 215 48 31
 
 
 {-| Provides the OrRd7-6 color.
 -}
 orrd7_6 : Color
 orrd7_6 =
-    rgb 153 0 0
+    rgb255 153 0 0
 
 
 {-| Provides the OrRd8 color scheme.
 -}
 orrd8 : List Color
 orrd8 =
-    [ rgb 255 247 236, rgb 254 232 200, rgb 253 212 158, rgb 253 187 132, rgb 252 141 89, rgb 239 101 72, rgb 215 48 31, rgb 153 0 0 ]
+    [ rgb255 255 247 236, rgb255 254 232 200, rgb255 253 212 158, rgb255 253 187 132, rgb255 252 141 89, rgb255 239 101 72, rgb255 215 48 31, rgb255 153 0 0 ]
 
 
 {-| Provides the OrRd8-0 color.
 -}
 orrd8_0 : Color
 orrd8_0 =
-    rgb 255 247 236
+    rgb255 255 247 236
 
 
 {-| Provides the OrRd8-1 color.
 -}
 orrd8_1 : Color
 orrd8_1 =
-    rgb 254 232 200
+    rgb255 254 232 200
 
 
 {-| Provides the OrRd8-2 color.
 -}
 orrd8_2 : Color
 orrd8_2 =
-    rgb 253 212 158
+    rgb255 253 212 158
 
 
 {-| Provides the OrRd8-3 color.
 -}
 orrd8_3 : Color
 orrd8_3 =
-    rgb 253 187 132
+    rgb255 253 187 132
 
 
 {-| Provides the OrRd8-4 color.
 -}
 orrd8_4 : Color
 orrd8_4 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the OrRd8-5 color.
 -}
 orrd8_5 : Color
 orrd8_5 =
-    rgb 239 101 72
+    rgb255 239 101 72
 
 
 {-| Provides the OrRd8-6 color.
 -}
 orrd8_6 : Color
 orrd8_6 =
-    rgb 215 48 31
+    rgb255 215 48 31
 
 
 {-| Provides the OrRd8-7 color.
 -}
 orrd8_7 : Color
 orrd8_7 =
-    rgb 153 0 0
+    rgb255 153 0 0
 
 
 {-| Provides the OrRd9 color scheme.
 -}
 orrd9 : List Color
 orrd9 =
-    [ rgb 255 247 236, rgb 254 232 200, rgb 253 212 158, rgb 253 187 132, rgb 252 141 89, rgb 239 101 72, rgb 215 48 31, rgb 179 0 0, rgb 127 0 0 ]
+    [ rgb255 255 247 236, rgb255 254 232 200, rgb255 253 212 158, rgb255 253 187 132, rgb255 252 141 89, rgb255 239 101 72, rgb255 215 48 31, rgb255 179 0 0, rgb255 127 0 0 ]
 
 
 {-| Provides the OrRd9-0 color.
 -}
 orrd9_0 : Color
 orrd9_0 =
-    rgb 255 247 236
+    rgb255 255 247 236
 
 
 {-| Provides the OrRd9-1 color.
 -}
 orrd9_1 : Color
 orrd9_1 =
-    rgb 254 232 200
+    rgb255 254 232 200
 
 
 {-| Provides the OrRd9-2 color.
 -}
 orrd9_2 : Color
 orrd9_2 =
-    rgb 253 212 158
+    rgb255 253 212 158
 
 
 {-| Provides the OrRd9-3 color.
 -}
 orrd9_3 : Color
 orrd9_3 =
-    rgb 253 187 132
+    rgb255 253 187 132
 
 
 {-| Provides the OrRd9-4 color.
 -}
 orrd9_4 : Color
 orrd9_4 =
-    rgb 252 141 89
+    rgb255 252 141 89
 
 
 {-| Provides the OrRd9-5 color.
 -}
 orrd9_5 : Color
 orrd9_5 =
-    rgb 239 101 72
+    rgb255 239 101 72
 
 
 {-| Provides the OrRd9-6 color.
 -}
 orrd9_6 : Color
 orrd9_6 =
-    rgb 215 48 31
+    rgb255 215 48 31
 
 
 {-| Provides the OrRd9-7 color.
 -}
 orrd9_7 : Color
 orrd9_7 =
-    rgb 179 0 0
+    rgb255 179 0 0
 
 
 {-| Provides the OrRd9-8 color.
 -}
 orrd9_8 : Color
 orrd9_8 =
-    rgb 127 0 0
+    rgb255 127 0 0
 
 
 {-| Provides the PuBu3 color scheme.
 -}
 pubu3 : List Color
 pubu3 =
-    [ rgb 236 231 242, rgb 166 189 219, rgb 43 140 190 ]
+    [ rgb255 236 231 242, rgb255 166 189 219, rgb255 43 140 190 ]
 
 
 {-| Provides the PuBu3-0 color.
 -}
 pubu3_0 : Color
 pubu3_0 =
-    rgb 236 231 242
+    rgb255 236 231 242
 
 
 {-| Provides the PuBu3-1 color.
 -}
 pubu3_1 : Color
 pubu3_1 =
-    rgb 166 189 219
+    rgb255 166 189 219
 
 
 {-| Provides the PuBu3-2 color.
 -}
 pubu3_2 : Color
 pubu3_2 =
-    rgb 43 140 190
+    rgb255 43 140 190
 
 
 {-| Provides the PuBu4 color scheme.
 -}
 pubu4 : List Color
 pubu4 =
-    [ rgb 241 238 246, rgb 189 201 225, rgb 116 169 207, rgb 5 112 176 ]
+    [ rgb255 241 238 246, rgb255 189 201 225, rgb255 116 169 207, rgb255 5 112 176 ]
 
 
 {-| Provides the PuBu4-0 color.
 -}
 pubu4_0 : Color
 pubu4_0 =
-    rgb 241 238 246
+    rgb255 241 238 246
 
 
 {-| Provides the PuBu4-1 color.
 -}
 pubu4_1 : Color
 pubu4_1 =
-    rgb 189 201 225
+    rgb255 189 201 225
 
 
 {-| Provides the PuBu4-2 color.
 -}
 pubu4_2 : Color
 pubu4_2 =
-    rgb 116 169 207
+    rgb255 116 169 207
 
 
 {-| Provides the PuBu4-3 color.
 -}
 pubu4_3 : Color
 pubu4_3 =
-    rgb 5 112 176
+    rgb255 5 112 176
 
 
 {-| Provides the PuBu5 color scheme.
 -}
 pubu5 : List Color
 pubu5 =
-    [ rgb 241 238 246, rgb 189 201 225, rgb 116 169 207, rgb 43 140 190, rgb 4 90 141 ]
+    [ rgb255 241 238 246, rgb255 189 201 225, rgb255 116 169 207, rgb255 43 140 190, rgb255 4 90 141 ]
 
 
 {-| Provides the PuBu5-0 color.
 -}
 pubu5_0 : Color
 pubu5_0 =
-    rgb 241 238 246
+    rgb255 241 238 246
 
 
 {-| Provides the PuBu5-1 color.
 -}
 pubu5_1 : Color
 pubu5_1 =
-    rgb 189 201 225
+    rgb255 189 201 225
 
 
 {-| Provides the PuBu5-2 color.
 -}
 pubu5_2 : Color
 pubu5_2 =
-    rgb 116 169 207
+    rgb255 116 169 207
 
 
 {-| Provides the PuBu5-3 color.
 -}
 pubu5_3 : Color
 pubu5_3 =
-    rgb 43 140 190
+    rgb255 43 140 190
 
 
 {-| Provides the PuBu5-4 color.
 -}
 pubu5_4 : Color
 pubu5_4 =
-    rgb 4 90 141
+    rgb255 4 90 141
 
 
 {-| Provides the PuBu6 color scheme.
 -}
 pubu6 : List Color
 pubu6 =
-    [ rgb 241 238 246, rgb 208 209 230, rgb 166 189 219, rgb 116 169 207, rgb 43 140 190, rgb 4 90 141 ]
+    [ rgb255 241 238 246, rgb255 208 209 230, rgb255 166 189 219, rgb255 116 169 207, rgb255 43 140 190, rgb255 4 90 141 ]
 
 
 {-| Provides the PuBu6-0 color.
 -}
 pubu6_0 : Color
 pubu6_0 =
-    rgb 241 238 246
+    rgb255 241 238 246
 
 
 {-| Provides the PuBu6-1 color.
 -}
 pubu6_1 : Color
 pubu6_1 =
-    rgb 208 209 230
+    rgb255 208 209 230
 
 
 {-| Provides the PuBu6-2 color.
 -}
 pubu6_2 : Color
 pubu6_2 =
-    rgb 166 189 219
+    rgb255 166 189 219
 
 
 {-| Provides the PuBu6-3 color.
 -}
 pubu6_3 : Color
 pubu6_3 =
-    rgb 116 169 207
+    rgb255 116 169 207
 
 
 {-| Provides the PuBu6-4 color.
 -}
 pubu6_4 : Color
 pubu6_4 =
-    rgb 43 140 190
+    rgb255 43 140 190
 
 
 {-| Provides the PuBu6-5 color.
 -}
 pubu6_5 : Color
 pubu6_5 =
-    rgb 4 90 141
+    rgb255 4 90 141
 
 
 {-| Provides the PuBu7 color scheme.
 -}
 pubu7 : List Color
 pubu7 =
-    [ rgb 241 238 246, rgb 208 209 230, rgb 166 189 219, rgb 116 169 207, rgb 54 144 192, rgb 5 112 176, rgb 3 78 123 ]
+    [ rgb255 241 238 246, rgb255 208 209 230, rgb255 166 189 219, rgb255 116 169 207, rgb255 54 144 192, rgb255 5 112 176, rgb255 3 78 123 ]
 
 
 {-| Provides the PuBu7-0 color.
 -}
 pubu7_0 : Color
 pubu7_0 =
-    rgb 241 238 246
+    rgb255 241 238 246
 
 
 {-| Provides the PuBu7-1 color.
 -}
 pubu7_1 : Color
 pubu7_1 =
-    rgb 208 209 230
+    rgb255 208 209 230
 
 
 {-| Provides the PuBu7-2 color.
 -}
 pubu7_2 : Color
 pubu7_2 =
-    rgb 166 189 219
+    rgb255 166 189 219
 
 
 {-| Provides the PuBu7-3 color.
 -}
 pubu7_3 : Color
 pubu7_3 =
-    rgb 116 169 207
+    rgb255 116 169 207
 
 
 {-| Provides the PuBu7-4 color.
 -}
 pubu7_4 : Color
 pubu7_4 =
-    rgb 54 144 192
+    rgb255 54 144 192
 
 
 {-| Provides the PuBu7-5 color.
 -}
 pubu7_5 : Color
 pubu7_5 =
-    rgb 5 112 176
+    rgb255 5 112 176
 
 
 {-| Provides the PuBu7-6 color.
 -}
 pubu7_6 : Color
 pubu7_6 =
-    rgb 3 78 123
+    rgb255 3 78 123
 
 
 {-| Provides the PuBu8 color scheme.
 -}
 pubu8 : List Color
 pubu8 =
-    [ rgb 255 247 251, rgb 236 231 242, rgb 208 209 230, rgb 166 189 219, rgb 116 169 207, rgb 54 144 192, rgb 5 112 176, rgb 3 78 123 ]
+    [ rgb255 255 247 251, rgb255 236 231 242, rgb255 208 209 230, rgb255 166 189 219, rgb255 116 169 207, rgb255 54 144 192, rgb255 5 112 176, rgb255 3 78 123 ]
 
 
 {-| Provides the PuBu8-0 color.
 -}
 pubu8_0 : Color
 pubu8_0 =
-    rgb 255 247 251
+    rgb255 255 247 251
 
 
 {-| Provides the PuBu8-1 color.
 -}
 pubu8_1 : Color
 pubu8_1 =
-    rgb 236 231 242
+    rgb255 236 231 242
 
 
 {-| Provides the PuBu8-2 color.
 -}
 pubu8_2 : Color
 pubu8_2 =
-    rgb 208 209 230
+    rgb255 208 209 230
 
 
 {-| Provides the PuBu8-3 color.
 -}
 pubu8_3 : Color
 pubu8_3 =
-    rgb 166 189 219
+    rgb255 166 189 219
 
 
 {-| Provides the PuBu8-4 color.
 -}
 pubu8_4 : Color
 pubu8_4 =
-    rgb 116 169 207
+    rgb255 116 169 207
 
 
 {-| Provides the PuBu8-5 color.
 -}
 pubu8_5 : Color
 pubu8_5 =
-    rgb 54 144 192
+    rgb255 54 144 192
 
 
 {-| Provides the PuBu8-6 color.
 -}
 pubu8_6 : Color
 pubu8_6 =
-    rgb 5 112 176
+    rgb255 5 112 176
 
 
 {-| Provides the PuBu8-7 color.
 -}
 pubu8_7 : Color
 pubu8_7 =
-    rgb 3 78 123
+    rgb255 3 78 123
 
 
 {-| Provides the PuBu9 color scheme.
 -}
 pubu9 : List Color
 pubu9 =
-    [ rgb 255 247 251, rgb 236 231 242, rgb 208 209 230, rgb 166 189 219, rgb 116 169 207, rgb 54 144 192, rgb 5 112 176, rgb 4 90 141, rgb 2 56 88 ]
+    [ rgb255 255 247 251, rgb255 236 231 242, rgb255 208 209 230, rgb255 166 189 219, rgb255 116 169 207, rgb255 54 144 192, rgb255 5 112 176, rgb255 4 90 141, rgb255 2 56 88 ]
 
 
 {-| Provides the PuBu9-0 color.
 -}
 pubu9_0 : Color
 pubu9_0 =
-    rgb 255 247 251
+    rgb255 255 247 251
 
 
 {-| Provides the PuBu9-1 color.
 -}
 pubu9_1 : Color
 pubu9_1 =
-    rgb 236 231 242
+    rgb255 236 231 242
 
 
 {-| Provides the PuBu9-2 color.
 -}
 pubu9_2 : Color
 pubu9_2 =
-    rgb 208 209 230
+    rgb255 208 209 230
 
 
 {-| Provides the PuBu9-3 color.
 -}
 pubu9_3 : Color
 pubu9_3 =
-    rgb 166 189 219
+    rgb255 166 189 219
 
 
 {-| Provides the PuBu9-4 color.
 -}
 pubu9_4 : Color
 pubu9_4 =
-    rgb 116 169 207
+    rgb255 116 169 207
 
 
 {-| Provides the PuBu9-5 color.
 -}
 pubu9_5 : Color
 pubu9_5 =
-    rgb 54 144 192
+    rgb255 54 144 192
 
 
 {-| Provides the PuBu9-6 color.
 -}
 pubu9_6 : Color
 pubu9_6 =
-    rgb 5 112 176
+    rgb255 5 112 176
 
 
 {-| Provides the PuBu9-7 color.
 -}
 pubu9_7 : Color
 pubu9_7 =
-    rgb 4 90 141
+    rgb255 4 90 141
 
 
 {-| Provides the PuBu9-8 color.
 -}
 pubu9_8 : Color
 pubu9_8 =
-    rgb 2 56 88
+    rgb255 2 56 88
 
 
 {-| Provides the BuPu3 color scheme.
 -}
 bupu3 : List Color
 bupu3 =
-    [ rgb 224 236 244, rgb 158 188 218, rgb 136 86 167 ]
+    [ rgb255 224 236 244, rgb255 158 188 218, rgb255 136 86 167 ]
 
 
 {-| Provides the BuPu3-0 color.
 -}
 bupu3_0 : Color
 bupu3_0 =
-    rgb 224 236 244
+    rgb255 224 236 244
 
 
 {-| Provides the BuPu3-1 color.
 -}
 bupu3_1 : Color
 bupu3_1 =
-    rgb 158 188 218
+    rgb255 158 188 218
 
 
 {-| Provides the BuPu3-2 color.
 -}
 bupu3_2 : Color
 bupu3_2 =
-    rgb 136 86 167
+    rgb255 136 86 167
 
 
 {-| Provides the BuPu4 color scheme.
 -}
 bupu4 : List Color
 bupu4 =
-    [ rgb 237 248 251, rgb 179 205 227, rgb 140 150 198, rgb 136 65 157 ]
+    [ rgb255 237 248 251, rgb255 179 205 227, rgb255 140 150 198, rgb255 136 65 157 ]
 
 
 {-| Provides the BuPu4-0 color.
 -}
 bupu4_0 : Color
 bupu4_0 =
-    rgb 237 248 251
+    rgb255 237 248 251
 
 
 {-| Provides the BuPu4-1 color.
 -}
 bupu4_1 : Color
 bupu4_1 =
-    rgb 179 205 227
+    rgb255 179 205 227
 
 
 {-| Provides the BuPu4-2 color.
 -}
 bupu4_2 : Color
 bupu4_2 =
-    rgb 140 150 198
+    rgb255 140 150 198
 
 
 {-| Provides the BuPu4-3 color.
 -}
 bupu4_3 : Color
 bupu4_3 =
-    rgb 136 65 157
+    rgb255 136 65 157
 
 
 {-| Provides the BuPu5 color scheme.
 -}
 bupu5 : List Color
 bupu5 =
-    [ rgb 237 248 251, rgb 179 205 227, rgb 140 150 198, rgb 136 86 167, rgb 129 15 124 ]
+    [ rgb255 237 248 251, rgb255 179 205 227, rgb255 140 150 198, rgb255 136 86 167, rgb255 129 15 124 ]
 
 
 {-| Provides the BuPu5-0 color.
 -}
 bupu5_0 : Color
 bupu5_0 =
-    rgb 237 248 251
+    rgb255 237 248 251
 
 
 {-| Provides the BuPu5-1 color.
 -}
 bupu5_1 : Color
 bupu5_1 =
-    rgb 179 205 227
+    rgb255 179 205 227
 
 
 {-| Provides the BuPu5-2 color.
 -}
 bupu5_2 : Color
 bupu5_2 =
-    rgb 140 150 198
+    rgb255 140 150 198
 
 
 {-| Provides the BuPu5-3 color.
 -}
 bupu5_3 : Color
 bupu5_3 =
-    rgb 136 86 167
+    rgb255 136 86 167
 
 
 {-| Provides the BuPu5-4 color.
 -}
 bupu5_4 : Color
 bupu5_4 =
-    rgb 129 15 124
+    rgb255 129 15 124
 
 
 {-| Provides the BuPu6 color scheme.
 -}
 bupu6 : List Color
 bupu6 =
-    [ rgb 237 248 251, rgb 191 211 230, rgb 158 188 218, rgb 140 150 198, rgb 136 86 167, rgb 129 15 124 ]
+    [ rgb255 237 248 251, rgb255 191 211 230, rgb255 158 188 218, rgb255 140 150 198, rgb255 136 86 167, rgb255 129 15 124 ]
 
 
 {-| Provides the BuPu6-0 color.
 -}
 bupu6_0 : Color
 bupu6_0 =
-    rgb 237 248 251
+    rgb255 237 248 251
 
 
 {-| Provides the BuPu6-1 color.
 -}
 bupu6_1 : Color
 bupu6_1 =
-    rgb 191 211 230
+    rgb255 191 211 230
 
 
 {-| Provides the BuPu6-2 color.
 -}
 bupu6_2 : Color
 bupu6_2 =
-    rgb 158 188 218
+    rgb255 158 188 218
 
 
 {-| Provides the BuPu6-3 color.
 -}
 bupu6_3 : Color
 bupu6_3 =
-    rgb 140 150 198
+    rgb255 140 150 198
 
 
 {-| Provides the BuPu6-4 color.
 -}
 bupu6_4 : Color
 bupu6_4 =
-    rgb 136 86 167
+    rgb255 136 86 167
 
 
 {-| Provides the BuPu6-5 color.
 -}
 bupu6_5 : Color
 bupu6_5 =
-    rgb 129 15 124
+    rgb255 129 15 124
 
 
 {-| Provides the BuPu7 color scheme.
 -}
 bupu7 : List Color
 bupu7 =
-    [ rgb 237 248 251, rgb 191 211 230, rgb 158 188 218, rgb 140 150 198, rgb 140 107 177, rgb 136 65 157, rgb 110 1 107 ]
+    [ rgb255 237 248 251, rgb255 191 211 230, rgb255 158 188 218, rgb255 140 150 198, rgb255 140 107 177, rgb255 136 65 157, rgb255 110 1 107 ]
 
 
 {-| Provides the BuPu7-0 color.
 -}
 bupu7_0 : Color
 bupu7_0 =
-    rgb 237 248 251
+    rgb255 237 248 251
 
 
 {-| Provides the BuPu7-1 color.
 -}
 bupu7_1 : Color
 bupu7_1 =
-    rgb 191 211 230
+    rgb255 191 211 230
 
 
 {-| Provides the BuPu7-2 color.
 -}
 bupu7_2 : Color
 bupu7_2 =
-    rgb 158 188 218
+    rgb255 158 188 218
 
 
 {-| Provides the BuPu7-3 color.
 -}
 bupu7_3 : Color
 bupu7_3 =
-    rgb 140 150 198
+    rgb255 140 150 198
 
 
 {-| Provides the BuPu7-4 color.
 -}
 bupu7_4 : Color
 bupu7_4 =
-    rgb 140 107 177
+    rgb255 140 107 177
 
 
 {-| Provides the BuPu7-5 color.
 -}
 bupu7_5 : Color
 bupu7_5 =
-    rgb 136 65 157
+    rgb255 136 65 157
 
 
 {-| Provides the BuPu7-6 color.
 -}
 bupu7_6 : Color
 bupu7_6 =
-    rgb 110 1 107
+    rgb255 110 1 107
 
 
 {-| Provides the BuPu8 color scheme.
 -}
 bupu8 : List Color
 bupu8 =
-    [ rgb 247 252 253, rgb 224 236 244, rgb 191 211 230, rgb 158 188 218, rgb 140 150 198, rgb 140 107 177, rgb 136 65 157, rgb 110 1 107 ]
+    [ rgb255 247 252 253, rgb255 224 236 244, rgb255 191 211 230, rgb255 158 188 218, rgb255 140 150 198, rgb255 140 107 177, rgb255 136 65 157, rgb255 110 1 107 ]
 
 
 {-| Provides the BuPu8-0 color.
 -}
 bupu8_0 : Color
 bupu8_0 =
-    rgb 247 252 253
+    rgb255 247 252 253
 
 
 {-| Provides the BuPu8-1 color.
 -}
 bupu8_1 : Color
 bupu8_1 =
-    rgb 224 236 244
+    rgb255 224 236 244
 
 
 {-| Provides the BuPu8-2 color.
 -}
 bupu8_2 : Color
 bupu8_2 =
-    rgb 191 211 230
+    rgb255 191 211 230
 
 
 {-| Provides the BuPu8-3 color.
 -}
 bupu8_3 : Color
 bupu8_3 =
-    rgb 158 188 218
+    rgb255 158 188 218
 
 
 {-| Provides the BuPu8-4 color.
 -}
 bupu8_4 : Color
 bupu8_4 =
-    rgb 140 150 198
+    rgb255 140 150 198
 
 
 {-| Provides the BuPu8-5 color.
 -}
 bupu8_5 : Color
 bupu8_5 =
-    rgb 140 107 177
+    rgb255 140 107 177
 
 
 {-| Provides the BuPu8-6 color.
 -}
 bupu8_6 : Color
 bupu8_6 =
-    rgb 136 65 157
+    rgb255 136 65 157
 
 
 {-| Provides the BuPu8-7 color.
 -}
 bupu8_7 : Color
 bupu8_7 =
-    rgb 110 1 107
+    rgb255 110 1 107
 
 
 {-| Provides the BuPu9 color scheme.
 -}
 bupu9 : List Color
 bupu9 =
-    [ rgb 247 252 253, rgb 224 236 244, rgb 191 211 230, rgb 158 188 218, rgb 140 150 198, rgb 140 107 177, rgb 136 65 157, rgb 129 15 124, rgb 77 0 75 ]
+    [ rgb255 247 252 253, rgb255 224 236 244, rgb255 191 211 230, rgb255 158 188 218, rgb255 140 150 198, rgb255 140 107 177, rgb255 136 65 157, rgb255 129 15 124, rgb255 77 0 75 ]
 
 
 {-| Provides the BuPu9-0 color.
 -}
 bupu9_0 : Color
 bupu9_0 =
-    rgb 247 252 253
+    rgb255 247 252 253
 
 
 {-| Provides the BuPu9-1 color.
 -}
 bupu9_1 : Color
 bupu9_1 =
-    rgb 224 236 244
+    rgb255 224 236 244
 
 
 {-| Provides the BuPu9-2 color.
 -}
 bupu9_2 : Color
 bupu9_2 =
-    rgb 191 211 230
+    rgb255 191 211 230
 
 
 {-| Provides the BuPu9-3 color.
 -}
 bupu9_3 : Color
 bupu9_3 =
-    rgb 158 188 218
+    rgb255 158 188 218
 
 
 {-| Provides the BuPu9-4 color.
 -}
 bupu9_4 : Color
 bupu9_4 =
-    rgb 140 150 198
+    rgb255 140 150 198
 
 
 {-| Provides the BuPu9-5 color.
 -}
 bupu9_5 : Color
 bupu9_5 =
-    rgb 140 107 177
+    rgb255 140 107 177
 
 
 {-| Provides the BuPu9-6 color.
 -}
 bupu9_6 : Color
 bupu9_6 =
-    rgb 136 65 157
+    rgb255 136 65 157
 
 
 {-| Provides the BuPu9-7 color.
 -}
 bupu9_7 : Color
 bupu9_7 =
-    rgb 129 15 124
+    rgb255 129 15 124
 
 
 {-| Provides the BuPu9-8 color.
 -}
 bupu9_8 : Color
 bupu9_8 =
-    rgb 77 0 75
+    rgb255 77 0 75
 
 
 {-| Provides the BuGn3 color scheme.
 -}
 bugn3 : List Color
 bugn3 =
-    [ rgb 229 245 249, rgb 153 216 201, rgb 44 162 95 ]
+    [ rgb255 229 245 249, rgb255 153 216 201, rgb255 44 162 95 ]
 
 
 {-| Provides the BuGn3-0 color.
 -}
 bugn3_0 : Color
 bugn3_0 =
-    rgb 229 245 249
+    rgb255 229 245 249
 
 
 {-| Provides the BuGn3-1 color.
 -}
 bugn3_1 : Color
 bugn3_1 =
-    rgb 153 216 201
+    rgb255 153 216 201
 
 
 {-| Provides the BuGn3-2 color.
 -}
 bugn3_2 : Color
 bugn3_2 =
-    rgb 44 162 95
+    rgb255 44 162 95
 
 
 {-| Provides the BuGn4 color scheme.
 -}
 bugn4 : List Color
 bugn4 =
-    [ rgb 237 248 251, rgb 178 226 226, rgb 102 194 164, rgb 35 139 69 ]
+    [ rgb255 237 248 251, rgb255 178 226 226, rgb255 102 194 164, rgb255 35 139 69 ]
 
 
 {-| Provides the BuGn4-0 color.
 -}
 bugn4_0 : Color
 bugn4_0 =
-    rgb 237 248 251
+    rgb255 237 248 251
 
 
 {-| Provides the BuGn4-1 color.
 -}
 bugn4_1 : Color
 bugn4_1 =
-    rgb 178 226 226
+    rgb255 178 226 226
 
 
 {-| Provides the BuGn4-2 color.
 -}
 bugn4_2 : Color
 bugn4_2 =
-    rgb 102 194 164
+    rgb255 102 194 164
 
 
 {-| Provides the BuGn4-3 color.
 -}
 bugn4_3 : Color
 bugn4_3 =
-    rgb 35 139 69
+    rgb255 35 139 69
 
 
 {-| Provides the BuGn5 color scheme.
 -}
 bugn5 : List Color
 bugn5 =
-    [ rgb 237 248 251, rgb 178 226 226, rgb 102 194 164, rgb 44 162 95, rgb 0 109 44 ]
+    [ rgb255 237 248 251, rgb255 178 226 226, rgb255 102 194 164, rgb255 44 162 95, rgb255 0 109 44 ]
 
 
 {-| Provides the BuGn5-0 color.
 -}
 bugn5_0 : Color
 bugn5_0 =
-    rgb 237 248 251
+    rgb255 237 248 251
 
 
 {-| Provides the BuGn5-1 color.
 -}
 bugn5_1 : Color
 bugn5_1 =
-    rgb 178 226 226
+    rgb255 178 226 226
 
 
 {-| Provides the BuGn5-2 color.
 -}
 bugn5_2 : Color
 bugn5_2 =
-    rgb 102 194 164
+    rgb255 102 194 164
 
 
 {-| Provides the BuGn5-3 color.
 -}
 bugn5_3 : Color
 bugn5_3 =
-    rgb 44 162 95
+    rgb255 44 162 95
 
 
 {-| Provides the BuGn5-4 color.
 -}
 bugn5_4 : Color
 bugn5_4 =
-    rgb 0 109 44
+    rgb255 0 109 44
 
 
 {-| Provides the BuGn6 color scheme.
 -}
 bugn6 : List Color
 bugn6 =
-    [ rgb 237 248 251, rgb 204 236 230, rgb 153 216 201, rgb 102 194 164, rgb 44 162 95, rgb 0 109 44 ]
+    [ rgb255 237 248 251, rgb255 204 236 230, rgb255 153 216 201, rgb255 102 194 164, rgb255 44 162 95, rgb255 0 109 44 ]
 
 
 {-| Provides the BuGn6-0 color.
 -}
 bugn6_0 : Color
 bugn6_0 =
-    rgb 237 248 251
+    rgb255 237 248 251
 
 
 {-| Provides the BuGn6-1 color.
 -}
 bugn6_1 : Color
 bugn6_1 =
-    rgb 204 236 230
+    rgb255 204 236 230
 
 
 {-| Provides the BuGn6-2 color.
 -}
 bugn6_2 : Color
 bugn6_2 =
-    rgb 153 216 201
+    rgb255 153 216 201
 
 
 {-| Provides the BuGn6-3 color.
 -}
 bugn6_3 : Color
 bugn6_3 =
-    rgb 102 194 164
+    rgb255 102 194 164
 
 
 {-| Provides the BuGn6-4 color.
 -}
 bugn6_4 : Color
 bugn6_4 =
-    rgb 44 162 95
+    rgb255 44 162 95
 
 
 {-| Provides the BuGn6-5 color.
 -}
 bugn6_5 : Color
 bugn6_5 =
-    rgb 0 109 44
+    rgb255 0 109 44
 
 
 {-| Provides the BuGn7 color scheme.
 -}
 bugn7 : List Color
 bugn7 =
-    [ rgb 237 248 251, rgb 204 236 230, rgb 153 216 201, rgb 102 194 164, rgb 65 174 118, rgb 35 139 69, rgb 0 88 36 ]
+    [ rgb255 237 248 251, rgb255 204 236 230, rgb255 153 216 201, rgb255 102 194 164, rgb255 65 174 118, rgb255 35 139 69, rgb255 0 88 36 ]
 
 
 {-| Provides the BuGn7-0 color.
 -}
 bugn7_0 : Color
 bugn7_0 =
-    rgb 237 248 251
+    rgb255 237 248 251
 
 
 {-| Provides the BuGn7-1 color.
 -}
 bugn7_1 : Color
 bugn7_1 =
-    rgb 204 236 230
+    rgb255 204 236 230
 
 
 {-| Provides the BuGn7-2 color.
 -}
 bugn7_2 : Color
 bugn7_2 =
-    rgb 153 216 201
+    rgb255 153 216 201
 
 
 {-| Provides the BuGn7-3 color.
 -}
 bugn7_3 : Color
 bugn7_3 =
-    rgb 102 194 164
+    rgb255 102 194 164
 
 
 {-| Provides the BuGn7-4 color.
 -}
 bugn7_4 : Color
 bugn7_4 =
-    rgb 65 174 118
+    rgb255 65 174 118
 
 
 {-| Provides the BuGn7-5 color.
 -}
 bugn7_5 : Color
 bugn7_5 =
-    rgb 35 139 69
+    rgb255 35 139 69
 
 
 {-| Provides the BuGn7-6 color.
 -}
 bugn7_6 : Color
 bugn7_6 =
-    rgb 0 88 36
+    rgb255 0 88 36
 
 
 {-| Provides the BuGn8 color scheme.
 -}
 bugn8 : List Color
 bugn8 =
-    [ rgb 247 252 253, rgb 229 245 249, rgb 204 236 230, rgb 153 216 201, rgb 102 194 164, rgb 65 174 118, rgb 35 139 69, rgb 0 88 36 ]
+    [ rgb255 247 252 253, rgb255 229 245 249, rgb255 204 236 230, rgb255 153 216 201, rgb255 102 194 164, rgb255 65 174 118, rgb255 35 139 69, rgb255 0 88 36 ]
 
 
 {-| Provides the BuGn8-0 color.
 -}
 bugn8_0 : Color
 bugn8_0 =
-    rgb 247 252 253
+    rgb255 247 252 253
 
 
 {-| Provides the BuGn8-1 color.
 -}
 bugn8_1 : Color
 bugn8_1 =
-    rgb 229 245 249
+    rgb255 229 245 249
 
 
 {-| Provides the BuGn8-2 color.
 -}
 bugn8_2 : Color
 bugn8_2 =
-    rgb 204 236 230
+    rgb255 204 236 230
 
 
 {-| Provides the BuGn8-3 color.
 -}
 bugn8_3 : Color
 bugn8_3 =
-    rgb 153 216 201
+    rgb255 153 216 201
 
 
 {-| Provides the BuGn8-4 color.
 -}
 bugn8_4 : Color
 bugn8_4 =
-    rgb 102 194 164
+    rgb255 102 194 164
 
 
 {-| Provides the BuGn8-5 color.
 -}
 bugn8_5 : Color
 bugn8_5 =
-    rgb 65 174 118
+    rgb255 65 174 118
 
 
 {-| Provides the BuGn8-6 color.
 -}
 bugn8_6 : Color
 bugn8_6 =
-    rgb 35 139 69
+    rgb255 35 139 69
 
 
 {-| Provides the BuGn8-7 color.
 -}
 bugn8_7 : Color
 bugn8_7 =
-    rgb 0 88 36
+    rgb255 0 88 36
 
 
 {-| Provides the BuGn9 color scheme.
 -}
 bugn9 : List Color
 bugn9 =
-    [ rgb 247 252 253, rgb 229 245 249, rgb 204 236 230, rgb 153 216 201, rgb 102 194 164, rgb 65 174 118, rgb 35 139 69, rgb 0 109 44, rgb 0 68 27 ]
+    [ rgb255 247 252 253, rgb255 229 245 249, rgb255 204 236 230, rgb255 153 216 201, rgb255 102 194 164, rgb255 65 174 118, rgb255 35 139 69, rgb255 0 109 44, rgb255 0 68 27 ]
 
 
 {-| Provides the BuGn9-0 color.
 -}
 bugn9_0 : Color
 bugn9_0 =
-    rgb 247 252 253
+    rgb255 247 252 253
 
 
 {-| Provides the BuGn9-1 color.
 -}
 bugn9_1 : Color
 bugn9_1 =
-    rgb 229 245 249
+    rgb255 229 245 249
 
 
 {-| Provides the BuGn9-2 color.
 -}
 bugn9_2 : Color
 bugn9_2 =
-    rgb 204 236 230
+    rgb255 204 236 230
 
 
 {-| Provides the BuGn9-3 color.
 -}
 bugn9_3 : Color
 bugn9_3 =
-    rgb 153 216 201
+    rgb255 153 216 201
 
 
 {-| Provides the BuGn9-4 color.
 -}
 bugn9_4 : Color
 bugn9_4 =
-    rgb 102 194 164
+    rgb255 102 194 164
 
 
 {-| Provides the BuGn9-5 color.
 -}
 bugn9_5 : Color
 bugn9_5 =
-    rgb 65 174 118
+    rgb255 65 174 118
 
 
 {-| Provides the BuGn9-6 color.
 -}
 bugn9_6 : Color
 bugn9_6 =
-    rgb 35 139 69
+    rgb255 35 139 69
 
 
 {-| Provides the BuGn9-7 color.
 -}
 bugn9_7 : Color
 bugn9_7 =
-    rgb 0 109 44
+    rgb255 0 109 44
 
 
 {-| Provides the BuGn9-8 color.
 -}
 bugn9_8 : Color
 bugn9_8 =
-    rgb 0 68 27
+    rgb255 0 68 27
 
 
 {-| Provides the YlOrBr3 color scheme.
 -}
 ylorbr3 : List Color
 ylorbr3 =
-    [ rgb 255 247 188, rgb 254 196 79, rgb 217 95 14 ]
+    [ rgb255 255 247 188, rgb255 254 196 79, rgb255 217 95 14 ]
 
 
 {-| Provides the YlOrBr3-0 color.
 -}
 ylorbr3_0 : Color
 ylorbr3_0 =
-    rgb 255 247 188
+    rgb255 255 247 188
 
 
 {-| Provides the YlOrBr3-1 color.
 -}
 ylorbr3_1 : Color
 ylorbr3_1 =
-    rgb 254 196 79
+    rgb255 254 196 79
 
 
 {-| Provides the YlOrBr3-2 color.
 -}
 ylorbr3_2 : Color
 ylorbr3_2 =
-    rgb 217 95 14
+    rgb255 217 95 14
 
 
 {-| Provides the YlOrBr4 color scheme.
 -}
 ylorbr4 : List Color
 ylorbr4 =
-    [ rgb 255 255 212, rgb 254 217 142, rgb 254 153 41, rgb 204 76 2 ]
+    [ rgb255 255 255 212, rgb255 254 217 142, rgb255 254 153 41, rgb255 204 76 2 ]
 
 
 {-| Provides the YlOrBr4-0 color.
 -}
 ylorbr4_0 : Color
 ylorbr4_0 =
-    rgb 255 255 212
+    rgb255 255 255 212
 
 
 {-| Provides the YlOrBr4-1 color.
 -}
 ylorbr4_1 : Color
 ylorbr4_1 =
-    rgb 254 217 142
+    rgb255 254 217 142
 
 
 {-| Provides the YlOrBr4-2 color.
 -}
 ylorbr4_2 : Color
 ylorbr4_2 =
-    rgb 254 153 41
+    rgb255 254 153 41
 
 
 {-| Provides the YlOrBr4-3 color.
 -}
 ylorbr4_3 : Color
 ylorbr4_3 =
-    rgb 204 76 2
+    rgb255 204 76 2
 
 
 {-| Provides the YlOrBr5 color scheme.
 -}
 ylorbr5 : List Color
 ylorbr5 =
-    [ rgb 255 255 212, rgb 254 217 142, rgb 254 153 41, rgb 217 95 14, rgb 153 52 4 ]
+    [ rgb255 255 255 212, rgb255 254 217 142, rgb255 254 153 41, rgb255 217 95 14, rgb255 153 52 4 ]
 
 
 {-| Provides the YlOrBr5-0 color.
 -}
 ylorbr5_0 : Color
 ylorbr5_0 =
-    rgb 255 255 212
+    rgb255 255 255 212
 
 
 {-| Provides the YlOrBr5-1 color.
 -}
 ylorbr5_1 : Color
 ylorbr5_1 =
-    rgb 254 217 142
+    rgb255 254 217 142
 
 
 {-| Provides the YlOrBr5-2 color.
 -}
 ylorbr5_2 : Color
 ylorbr5_2 =
-    rgb 254 153 41
+    rgb255 254 153 41
 
 
 {-| Provides the YlOrBr5-3 color.
 -}
 ylorbr5_3 : Color
 ylorbr5_3 =
-    rgb 217 95 14
+    rgb255 217 95 14
 
 
 {-| Provides the YlOrBr5-4 color.
 -}
 ylorbr5_4 : Color
 ylorbr5_4 =
-    rgb 153 52 4
+    rgb255 153 52 4
 
 
 {-| Provides the YlOrBr6 color scheme.
 -}
 ylorbr6 : List Color
 ylorbr6 =
-    [ rgb 255 255 212, rgb 254 227 145, rgb 254 196 79, rgb 254 153 41, rgb 217 95 14, rgb 153 52 4 ]
+    [ rgb255 255 255 212, rgb255 254 227 145, rgb255 254 196 79, rgb255 254 153 41, rgb255 217 95 14, rgb255 153 52 4 ]
 
 
 {-| Provides the YlOrBr6-0 color.
 -}
 ylorbr6_0 : Color
 ylorbr6_0 =
-    rgb 255 255 212
+    rgb255 255 255 212
 
 
 {-| Provides the YlOrBr6-1 color.
 -}
 ylorbr6_1 : Color
 ylorbr6_1 =
-    rgb 254 227 145
+    rgb255 254 227 145
 
 
 {-| Provides the YlOrBr6-2 color.
 -}
 ylorbr6_2 : Color
 ylorbr6_2 =
-    rgb 254 196 79
+    rgb255 254 196 79
 
 
 {-| Provides the YlOrBr6-3 color.
 -}
 ylorbr6_3 : Color
 ylorbr6_3 =
-    rgb 254 153 41
+    rgb255 254 153 41
 
 
 {-| Provides the YlOrBr6-4 color.
 -}
 ylorbr6_4 : Color
 ylorbr6_4 =
-    rgb 217 95 14
+    rgb255 217 95 14
 
 
 {-| Provides the YlOrBr6-5 color.
 -}
 ylorbr6_5 : Color
 ylorbr6_5 =
-    rgb 153 52 4
+    rgb255 153 52 4
 
 
 {-| Provides the YlOrBr7 color scheme.
 -}
 ylorbr7 : List Color
 ylorbr7 =
-    [ rgb 255 255 212, rgb 254 227 145, rgb 254 196 79, rgb 254 153 41, rgb 236 112 20, rgb 204 76 2, rgb 140 45 4 ]
+    [ rgb255 255 255 212, rgb255 254 227 145, rgb255 254 196 79, rgb255 254 153 41, rgb255 236 112 20, rgb255 204 76 2, rgb255 140 45 4 ]
 
 
 {-| Provides the YlOrBr7-0 color.
 -}
 ylorbr7_0 : Color
 ylorbr7_0 =
-    rgb 255 255 212
+    rgb255 255 255 212
 
 
 {-| Provides the YlOrBr7-1 color.
 -}
 ylorbr7_1 : Color
 ylorbr7_1 =
-    rgb 254 227 145
+    rgb255 254 227 145
 
 
 {-| Provides the YlOrBr7-2 color.
 -}
 ylorbr7_2 : Color
 ylorbr7_2 =
-    rgb 254 196 79
+    rgb255 254 196 79
 
 
 {-| Provides the YlOrBr7-3 color.
 -}
 ylorbr7_3 : Color
 ylorbr7_3 =
-    rgb 254 153 41
+    rgb255 254 153 41
 
 
 {-| Provides the YlOrBr7-4 color.
 -}
 ylorbr7_4 : Color
 ylorbr7_4 =
-    rgb 236 112 20
+    rgb255 236 112 20
 
 
 {-| Provides the YlOrBr7-5 color.
 -}
 ylorbr7_5 : Color
 ylorbr7_5 =
-    rgb 204 76 2
+    rgb255 204 76 2
 
 
 {-| Provides the YlOrBr7-6 color.
 -}
 ylorbr7_6 : Color
 ylorbr7_6 =
-    rgb 140 45 4
+    rgb255 140 45 4
 
 
 {-| Provides the YlOrBr8 color scheme.
 -}
 ylorbr8 : List Color
 ylorbr8 =
-    [ rgb 255 255 229, rgb 255 247 188, rgb 254 227 145, rgb 254 196 79, rgb 254 153 41, rgb 236 112 20, rgb 204 76 2, rgb 140 45 4 ]
+    [ rgb255 255 255 229, rgb255 255 247 188, rgb255 254 227 145, rgb255 254 196 79, rgb255 254 153 41, rgb255 236 112 20, rgb255 204 76 2, rgb255 140 45 4 ]
 
 
 {-| Provides the YlOrBr8-0 color.
 -}
 ylorbr8_0 : Color
 ylorbr8_0 =
-    rgb 255 255 229
+    rgb255 255 255 229
 
 
 {-| Provides the YlOrBr8-1 color.
 -}
 ylorbr8_1 : Color
 ylorbr8_1 =
-    rgb 255 247 188
+    rgb255 255 247 188
 
 
 {-| Provides the YlOrBr8-2 color.
 -}
 ylorbr8_2 : Color
 ylorbr8_2 =
-    rgb 254 227 145
+    rgb255 254 227 145
 
 
 {-| Provides the YlOrBr8-3 color.
 -}
 ylorbr8_3 : Color
 ylorbr8_3 =
-    rgb 254 196 79
+    rgb255 254 196 79
 
 
 {-| Provides the YlOrBr8-4 color.
 -}
 ylorbr8_4 : Color
 ylorbr8_4 =
-    rgb 254 153 41
+    rgb255 254 153 41
 
 
 {-| Provides the YlOrBr8-5 color.
 -}
 ylorbr8_5 : Color
 ylorbr8_5 =
-    rgb 236 112 20
+    rgb255 236 112 20
 
 
 {-| Provides the YlOrBr8-6 color.
 -}
 ylorbr8_6 : Color
 ylorbr8_6 =
-    rgb 204 76 2
+    rgb255 204 76 2
 
 
 {-| Provides the YlOrBr8-7 color.
 -}
 ylorbr8_7 : Color
 ylorbr8_7 =
-    rgb 140 45 4
+    rgb255 140 45 4
 
 
 {-| Provides the YlOrBr9 color scheme.
 -}
 ylorbr9 : List Color
 ylorbr9 =
-    [ rgb 255 255 229, rgb 255 247 188, rgb 254 227 145, rgb 254 196 79, rgb 254 153 41, rgb 236 112 20, rgb 204 76 2, rgb 153 52 4, rgb 102 37 6 ]
+    [ rgb255 255 255 229, rgb255 255 247 188, rgb255 254 227 145, rgb255 254 196 79, rgb255 254 153 41, rgb255 236 112 20, rgb255 204 76 2, rgb255 153 52 4, rgb255 102 37 6 ]
 
 
 {-| Provides the YlOrBr9-0 color.
 -}
 ylorbr9_0 : Color
 ylorbr9_0 =
-    rgb 255 255 229
+    rgb255 255 255 229
 
 
 {-| Provides the YlOrBr9-1 color.
 -}
 ylorbr9_1 : Color
 ylorbr9_1 =
-    rgb 255 247 188
+    rgb255 255 247 188
 
 
 {-| Provides the YlOrBr9-2 color.
 -}
 ylorbr9_2 : Color
 ylorbr9_2 =
-    rgb 254 227 145
+    rgb255 254 227 145
 
 
 {-| Provides the YlOrBr9-3 color.
 -}
 ylorbr9_3 : Color
 ylorbr9_3 =
-    rgb 254 196 79
+    rgb255 254 196 79
 
 
 {-| Provides the YlOrBr9-4 color.
 -}
 ylorbr9_4 : Color
 ylorbr9_4 =
-    rgb 254 153 41
+    rgb255 254 153 41
 
 
 {-| Provides the YlOrBr9-5 color.
 -}
 ylorbr9_5 : Color
 ylorbr9_5 =
-    rgb 236 112 20
+    rgb255 236 112 20
 
 
 {-| Provides the YlOrBr9-6 color.
 -}
 ylorbr9_6 : Color
 ylorbr9_6 =
-    rgb 204 76 2
+    rgb255 204 76 2
 
 
 {-| Provides the YlOrBr9-7 color.
 -}
 ylorbr9_7 : Color
 ylorbr9_7 =
-    rgb 153 52 4
+    rgb255 153 52 4
 
 
 {-| Provides the YlOrBr9-8 color.
 -}
 ylorbr9_8 : Color
 ylorbr9_8 =
-    rgb 102 37 6
+    rgb255 102 37 6
 
 
 {-| Provides the YlGn3 color scheme.
 -}
 ylgn3 : List Color
 ylgn3 =
-    [ rgb 247 252 185, rgb 173 221 142, rgb 49 163 84 ]
+    [ rgb255 247 252 185, rgb255 173 221 142, rgb255 49 163 84 ]
 
 
 {-| Provides the YlGn3-0 color.
 -}
 ylgn3_0 : Color
 ylgn3_0 =
-    rgb 247 252 185
+    rgb255 247 252 185
 
 
 {-| Provides the YlGn3-1 color.
 -}
 ylgn3_1 : Color
 ylgn3_1 =
-    rgb 173 221 142
+    rgb255 173 221 142
 
 
 {-| Provides the YlGn3-2 color.
 -}
 ylgn3_2 : Color
 ylgn3_2 =
-    rgb 49 163 84
+    rgb255 49 163 84
 
 
 {-| Provides the YlGn4 color scheme.
 -}
 ylgn4 : List Color
 ylgn4 =
-    [ rgb 255 255 204, rgb 194 230 153, rgb 120 198 121, rgb 35 132 67 ]
+    [ rgb255 255 255 204, rgb255 194 230 153, rgb255 120 198 121, rgb255 35 132 67 ]
 
 
 {-| Provides the YlGn4-0 color.
 -}
 ylgn4_0 : Color
 ylgn4_0 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the YlGn4-1 color.
 -}
 ylgn4_1 : Color
 ylgn4_1 =
-    rgb 194 230 153
+    rgb255 194 230 153
 
 
 {-| Provides the YlGn4-2 color.
 -}
 ylgn4_2 : Color
 ylgn4_2 =
-    rgb 120 198 121
+    rgb255 120 198 121
 
 
 {-| Provides the YlGn4-3 color.
 -}
 ylgn4_3 : Color
 ylgn4_3 =
-    rgb 35 132 67
+    rgb255 35 132 67
 
 
 {-| Provides the YlGn5 color scheme.
 -}
 ylgn5 : List Color
 ylgn5 =
-    [ rgb 255 255 204, rgb 194 230 153, rgb 120 198 121, rgb 49 163 84, rgb 0 104 55 ]
+    [ rgb255 255 255 204, rgb255 194 230 153, rgb255 120 198 121, rgb255 49 163 84, rgb255 0 104 55 ]
 
 
 {-| Provides the YlGn5-0 color.
 -}
 ylgn5_0 : Color
 ylgn5_0 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the YlGn5-1 color.
 -}
 ylgn5_1 : Color
 ylgn5_1 =
-    rgb 194 230 153
+    rgb255 194 230 153
 
 
 {-| Provides the YlGn5-2 color.
 -}
 ylgn5_2 : Color
 ylgn5_2 =
-    rgb 120 198 121
+    rgb255 120 198 121
 
 
 {-| Provides the YlGn5-3 color.
 -}
 ylgn5_3 : Color
 ylgn5_3 =
-    rgb 49 163 84
+    rgb255 49 163 84
 
 
 {-| Provides the YlGn5-4 color.
 -}
 ylgn5_4 : Color
 ylgn5_4 =
-    rgb 0 104 55
+    rgb255 0 104 55
 
 
 {-| Provides the YlGn6 color scheme.
 -}
 ylgn6 : List Color
 ylgn6 =
-    [ rgb 255 255 204, rgb 217 240 163, rgb 173 221 142, rgb 120 198 121, rgb 49 163 84, rgb 0 104 55 ]
+    [ rgb255 255 255 204, rgb255 217 240 163, rgb255 173 221 142, rgb255 120 198 121, rgb255 49 163 84, rgb255 0 104 55 ]
 
 
 {-| Provides the YlGn6-0 color.
 -}
 ylgn6_0 : Color
 ylgn6_0 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the YlGn6-1 color.
 -}
 ylgn6_1 : Color
 ylgn6_1 =
-    rgb 217 240 163
+    rgb255 217 240 163
 
 
 {-| Provides the YlGn6-2 color.
 -}
 ylgn6_2 : Color
 ylgn6_2 =
-    rgb 173 221 142
+    rgb255 173 221 142
 
 
 {-| Provides the YlGn6-3 color.
 -}
 ylgn6_3 : Color
 ylgn6_3 =
-    rgb 120 198 121
+    rgb255 120 198 121
 
 
 {-| Provides the YlGn6-4 color.
 -}
 ylgn6_4 : Color
 ylgn6_4 =
-    rgb 49 163 84
+    rgb255 49 163 84
 
 
 {-| Provides the YlGn6-5 color.
 -}
 ylgn6_5 : Color
 ylgn6_5 =
-    rgb 0 104 55
+    rgb255 0 104 55
 
 
 {-| Provides the YlGn7 color scheme.
 -}
 ylgn7 : List Color
 ylgn7 =
-    [ rgb 255 255 204, rgb 217 240 163, rgb 173 221 142, rgb 120 198 121, rgb 65 171 93, rgb 35 132 67, rgb 0 90 50 ]
+    [ rgb255 255 255 204, rgb255 217 240 163, rgb255 173 221 142, rgb255 120 198 121, rgb255 65 171 93, rgb255 35 132 67, rgb255 0 90 50 ]
 
 
 {-| Provides the YlGn7-0 color.
 -}
 ylgn7_0 : Color
 ylgn7_0 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the YlGn7-1 color.
 -}
 ylgn7_1 : Color
 ylgn7_1 =
-    rgb 217 240 163
+    rgb255 217 240 163
 
 
 {-| Provides the YlGn7-2 color.
 -}
 ylgn7_2 : Color
 ylgn7_2 =
-    rgb 173 221 142
+    rgb255 173 221 142
 
 
 {-| Provides the YlGn7-3 color.
 -}
 ylgn7_3 : Color
 ylgn7_3 =
-    rgb 120 198 121
+    rgb255 120 198 121
 
 
 {-| Provides the YlGn7-4 color.
 -}
 ylgn7_4 : Color
 ylgn7_4 =
-    rgb 65 171 93
+    rgb255 65 171 93
 
 
 {-| Provides the YlGn7-5 color.
 -}
 ylgn7_5 : Color
 ylgn7_5 =
-    rgb 35 132 67
+    rgb255 35 132 67
 
 
 {-| Provides the YlGn7-6 color.
 -}
 ylgn7_6 : Color
 ylgn7_6 =
-    rgb 0 90 50
+    rgb255 0 90 50
 
 
 {-| Provides the YlGn8 color scheme.
 -}
 ylgn8 : List Color
 ylgn8 =
-    [ rgb 255 255 229, rgb 247 252 185, rgb 217 240 163, rgb 173 221 142, rgb 120 198 121, rgb 65 171 93, rgb 35 132 67, rgb 0 90 50 ]
+    [ rgb255 255 255 229, rgb255 247 252 185, rgb255 217 240 163, rgb255 173 221 142, rgb255 120 198 121, rgb255 65 171 93, rgb255 35 132 67, rgb255 0 90 50 ]
 
 
 {-| Provides the YlGn8-0 color.
 -}
 ylgn8_0 : Color
 ylgn8_0 =
-    rgb 255 255 229
+    rgb255 255 255 229
 
 
 {-| Provides the YlGn8-1 color.
 -}
 ylgn8_1 : Color
 ylgn8_1 =
-    rgb 247 252 185
+    rgb255 247 252 185
 
 
 {-| Provides the YlGn8-2 color.
 -}
 ylgn8_2 : Color
 ylgn8_2 =
-    rgb 217 240 163
+    rgb255 217 240 163
 
 
 {-| Provides the YlGn8-3 color.
 -}
 ylgn8_3 : Color
 ylgn8_3 =
-    rgb 173 221 142
+    rgb255 173 221 142
 
 
 {-| Provides the YlGn8-4 color.
 -}
 ylgn8_4 : Color
 ylgn8_4 =
-    rgb 120 198 121
+    rgb255 120 198 121
 
 
 {-| Provides the YlGn8-5 color.
 -}
 ylgn8_5 : Color
 ylgn8_5 =
-    rgb 65 171 93
+    rgb255 65 171 93
 
 
 {-| Provides the YlGn8-6 color.
 -}
 ylgn8_6 : Color
 ylgn8_6 =
-    rgb 35 132 67
+    rgb255 35 132 67
 
 
 {-| Provides the YlGn8-7 color.
 -}
 ylgn8_7 : Color
 ylgn8_7 =
-    rgb 0 90 50
+    rgb255 0 90 50
 
 
 {-| Provides the YlGn9 color scheme.
 -}
 ylgn9 : List Color
 ylgn9 =
-    [ rgb 255 255 229, rgb 247 252 185, rgb 217 240 163, rgb 173 221 142, rgb 120 198 121, rgb 65 171 93, rgb 35 132 67, rgb 0 104 55, rgb 0 69 41 ]
+    [ rgb255 255 255 229, rgb255 247 252 185, rgb255 217 240 163, rgb255 173 221 142, rgb255 120 198 121, rgb255 65 171 93, rgb255 35 132 67, rgb255 0 104 55, rgb255 0 69 41 ]
 
 
 {-| Provides the YlGn9-0 color.
 -}
 ylgn9_0 : Color
 ylgn9_0 =
-    rgb 255 255 229
+    rgb255 255 255 229
 
 
 {-| Provides the YlGn9-1 color.
 -}
 ylgn9_1 : Color
 ylgn9_1 =
-    rgb 247 252 185
+    rgb255 247 252 185
 
 
 {-| Provides the YlGn9-2 color.
 -}
 ylgn9_2 : Color
 ylgn9_2 =
-    rgb 217 240 163
+    rgb255 217 240 163
 
 
 {-| Provides the YlGn9-3 color.
 -}
 ylgn9_3 : Color
 ylgn9_3 =
-    rgb 173 221 142
+    rgb255 173 221 142
 
 
 {-| Provides the YlGn9-4 color.
 -}
 ylgn9_4 : Color
 ylgn9_4 =
-    rgb 120 198 121
+    rgb255 120 198 121
 
 
 {-| Provides the YlGn9-5 color.
 -}
 ylgn9_5 : Color
 ylgn9_5 =
-    rgb 65 171 93
+    rgb255 65 171 93
 
 
 {-| Provides the YlGn9-6 color.
 -}
 ylgn9_6 : Color
 ylgn9_6 =
-    rgb 35 132 67
+    rgb255 35 132 67
 
 
 {-| Provides the YlGn9-7 color.
 -}
 ylgn9_7 : Color
 ylgn9_7 =
-    rgb 0 104 55
+    rgb255 0 104 55
 
 
 {-| Provides the YlGn9-8 color.
 -}
 ylgn9_8 : Color
 ylgn9_8 =
-    rgb 0 69 41
+    rgb255 0 69 41
 
 
 {-| Provides the RdPu3 color scheme.
 -}
 rdpu3 : List Color
 rdpu3 =
-    [ rgb 253 224 221, rgb 250 159 181, rgb 197 27 138 ]
+    [ rgb255 253 224 221, rgb255 250 159 181, rgb255 197 27 138 ]
 
 
 {-| Provides the RdPu3-0 color.
 -}
 rdpu3_0 : Color
 rdpu3_0 =
-    rgb 253 224 221
+    rgb255 253 224 221
 
 
 {-| Provides the RdPu3-1 color.
 -}
 rdpu3_1 : Color
 rdpu3_1 =
-    rgb 250 159 181
+    rgb255 250 159 181
 
 
 {-| Provides the RdPu3-2 color.
 -}
 rdpu3_2 : Color
 rdpu3_2 =
-    rgb 197 27 138
+    rgb255 197 27 138
 
 
 {-| Provides the RdPu4 color scheme.
 -}
 rdpu4 : List Color
 rdpu4 =
-    [ rgb 254 235 226, rgb 251 180 185, rgb 247 104 161, rgb 174 1 126 ]
+    [ rgb255 254 235 226, rgb255 251 180 185, rgb255 247 104 161, rgb255 174 1 126 ]
 
 
 {-| Provides the RdPu4-0 color.
 -}
 rdpu4_0 : Color
 rdpu4_0 =
-    rgb 254 235 226
+    rgb255 254 235 226
 
 
 {-| Provides the RdPu4-1 color.
 -}
 rdpu4_1 : Color
 rdpu4_1 =
-    rgb 251 180 185
+    rgb255 251 180 185
 
 
 {-| Provides the RdPu4-2 color.
 -}
 rdpu4_2 : Color
 rdpu4_2 =
-    rgb 247 104 161
+    rgb255 247 104 161
 
 
 {-| Provides the RdPu4-3 color.
 -}
 rdpu4_3 : Color
 rdpu4_3 =
-    rgb 174 1 126
+    rgb255 174 1 126
 
 
 {-| Provides the RdPu5 color scheme.
 -}
 rdpu5 : List Color
 rdpu5 =
-    [ rgb 254 235 226, rgb 251 180 185, rgb 247 104 161, rgb 197 27 138, rgb 122 1 119 ]
+    [ rgb255 254 235 226, rgb255 251 180 185, rgb255 247 104 161, rgb255 197 27 138, rgb255 122 1 119 ]
 
 
 {-| Provides the RdPu5-0 color.
 -}
 rdpu5_0 : Color
 rdpu5_0 =
-    rgb 254 235 226
+    rgb255 254 235 226
 
 
 {-| Provides the RdPu5-1 color.
 -}
 rdpu5_1 : Color
 rdpu5_1 =
-    rgb 251 180 185
+    rgb255 251 180 185
 
 
 {-| Provides the RdPu5-2 color.
 -}
 rdpu5_2 : Color
 rdpu5_2 =
-    rgb 247 104 161
+    rgb255 247 104 161
 
 
 {-| Provides the RdPu5-3 color.
 -}
 rdpu5_3 : Color
 rdpu5_3 =
-    rgb 197 27 138
+    rgb255 197 27 138
 
 
 {-| Provides the RdPu5-4 color.
 -}
 rdpu5_4 : Color
 rdpu5_4 =
-    rgb 122 1 119
+    rgb255 122 1 119
 
 
 {-| Provides the RdPu6 color scheme.
 -}
 rdpu6 : List Color
 rdpu6 =
-    [ rgb 254 235 226, rgb 252 197 192, rgb 250 159 181, rgb 247 104 161, rgb 197 27 138, rgb 122 1 119 ]
+    [ rgb255 254 235 226, rgb255 252 197 192, rgb255 250 159 181, rgb255 247 104 161, rgb255 197 27 138, rgb255 122 1 119 ]
 
 
 {-| Provides the RdPu6-0 color.
 -}
 rdpu6_0 : Color
 rdpu6_0 =
-    rgb 254 235 226
+    rgb255 254 235 226
 
 
 {-| Provides the RdPu6-1 color.
 -}
 rdpu6_1 : Color
 rdpu6_1 =
-    rgb 252 197 192
+    rgb255 252 197 192
 
 
 {-| Provides the RdPu6-2 color.
 -}
 rdpu6_2 : Color
 rdpu6_2 =
-    rgb 250 159 181
+    rgb255 250 159 181
 
 
 {-| Provides the RdPu6-3 color.
 -}
 rdpu6_3 : Color
 rdpu6_3 =
-    rgb 247 104 161
+    rgb255 247 104 161
 
 
 {-| Provides the RdPu6-4 color.
 -}
 rdpu6_4 : Color
 rdpu6_4 =
-    rgb 197 27 138
+    rgb255 197 27 138
 
 
 {-| Provides the RdPu6-5 color.
 -}
 rdpu6_5 : Color
 rdpu6_5 =
-    rgb 122 1 119
+    rgb255 122 1 119
 
 
 {-| Provides the RdPu7 color scheme.
 -}
 rdpu7 : List Color
 rdpu7 =
-    [ rgb 254 235 226, rgb 252 197 192, rgb 250 159 181, rgb 247 104 161, rgb 221 52 151, rgb 174 1 126, rgb 122 1 119 ]
+    [ rgb255 254 235 226, rgb255 252 197 192, rgb255 250 159 181, rgb255 247 104 161, rgb255 221 52 151, rgb255 174 1 126, rgb255 122 1 119 ]
 
 
 {-| Provides the RdPu7-0 color.
 -}
 rdpu7_0 : Color
 rdpu7_0 =
-    rgb 254 235 226
+    rgb255 254 235 226
 
 
 {-| Provides the RdPu7-1 color.
 -}
 rdpu7_1 : Color
 rdpu7_1 =
-    rgb 252 197 192
+    rgb255 252 197 192
 
 
 {-| Provides the RdPu7-2 color.
 -}
 rdpu7_2 : Color
 rdpu7_2 =
-    rgb 250 159 181
+    rgb255 250 159 181
 
 
 {-| Provides the RdPu7-3 color.
 -}
 rdpu7_3 : Color
 rdpu7_3 =
-    rgb 247 104 161
+    rgb255 247 104 161
 
 
 {-| Provides the RdPu7-4 color.
 -}
 rdpu7_4 : Color
 rdpu7_4 =
-    rgb 221 52 151
+    rgb255 221 52 151
 
 
 {-| Provides the RdPu7-5 color.
 -}
 rdpu7_5 : Color
 rdpu7_5 =
-    rgb 174 1 126
+    rgb255 174 1 126
 
 
 {-| Provides the RdPu7-6 color.
 -}
 rdpu7_6 : Color
 rdpu7_6 =
-    rgb 122 1 119
+    rgb255 122 1 119
 
 
 {-| Provides the RdPu8 color scheme.
 -}
 rdpu8 : List Color
 rdpu8 =
-    [ rgb 255 247 243, rgb 253 224 221, rgb 252 197 192, rgb 250 159 181, rgb 247 104 161, rgb 221 52 151, rgb 174 1 126, rgb 122 1 119 ]
+    [ rgb255 255 247 243, rgb255 253 224 221, rgb255 252 197 192, rgb255 250 159 181, rgb255 247 104 161, rgb255 221 52 151, rgb255 174 1 126, rgb255 122 1 119 ]
 
 
 {-| Provides the RdPu8-0 color.
 -}
 rdpu8_0 : Color
 rdpu8_0 =
-    rgb 255 247 243
+    rgb255 255 247 243
 
 
 {-| Provides the RdPu8-1 color.
 -}
 rdpu8_1 : Color
 rdpu8_1 =
-    rgb 253 224 221
+    rgb255 253 224 221
 
 
 {-| Provides the RdPu8-2 color.
 -}
 rdpu8_2 : Color
 rdpu8_2 =
-    rgb 252 197 192
+    rgb255 252 197 192
 
 
 {-| Provides the RdPu8-3 color.
 -}
 rdpu8_3 : Color
 rdpu8_3 =
-    rgb 250 159 181
+    rgb255 250 159 181
 
 
 {-| Provides the RdPu8-4 color.
 -}
 rdpu8_4 : Color
 rdpu8_4 =
-    rgb 247 104 161
+    rgb255 247 104 161
 
 
 {-| Provides the RdPu8-5 color.
 -}
 rdpu8_5 : Color
 rdpu8_5 =
-    rgb 221 52 151
+    rgb255 221 52 151
 
 
 {-| Provides the RdPu8-6 color.
 -}
 rdpu8_6 : Color
 rdpu8_6 =
-    rgb 174 1 126
+    rgb255 174 1 126
 
 
 {-| Provides the RdPu8-7 color.
 -}
 rdpu8_7 : Color
 rdpu8_7 =
-    rgb 122 1 119
+    rgb255 122 1 119
 
 
 {-| Provides the RdPu9 color scheme.
 -}
 rdpu9 : List Color
 rdpu9 =
-    [ rgb 255 247 243, rgb 253 224 221, rgb 252 197 192, rgb 250 159 181, rgb 247 104 161, rgb 221 52 151, rgb 174 1 126, rgb 122 1 119, rgb 73 0 106 ]
+    [ rgb255 255 247 243, rgb255 253 224 221, rgb255 252 197 192, rgb255 250 159 181, rgb255 247 104 161, rgb255 221 52 151, rgb255 174 1 126, rgb255 122 1 119, rgb255 73 0 106 ]
 
 
 {-| Provides the RdPu9-0 color.
 -}
 rdpu9_0 : Color
 rdpu9_0 =
-    rgb 255 247 243
+    rgb255 255 247 243
 
 
 {-| Provides the RdPu9-1 color.
 -}
 rdpu9_1 : Color
 rdpu9_1 =
-    rgb 253 224 221
+    rgb255 253 224 221
 
 
 {-| Provides the RdPu9-2 color.
 -}
 rdpu9_2 : Color
 rdpu9_2 =
-    rgb 252 197 192
+    rgb255 252 197 192
 
 
 {-| Provides the RdPu9-3 color.
 -}
 rdpu9_3 : Color
 rdpu9_3 =
-    rgb 250 159 181
+    rgb255 250 159 181
 
 
 {-| Provides the RdPu9-4 color.
 -}
 rdpu9_4 : Color
 rdpu9_4 =
-    rgb 247 104 161
+    rgb255 247 104 161
 
 
 {-| Provides the RdPu9-5 color.
 -}
 rdpu9_5 : Color
 rdpu9_5 =
-    rgb 221 52 151
+    rgb255 221 52 151
 
 
 {-| Provides the RdPu9-6 color.
 -}
 rdpu9_6 : Color
 rdpu9_6 =
-    rgb 174 1 126
+    rgb255 174 1 126
 
 
 {-| Provides the RdPu9-7 color.
 -}
 rdpu9_7 : Color
 rdpu9_7 =
-    rgb 122 1 119
+    rgb255 122 1 119
 
 
 {-| Provides the RdPu9-8 color.
 -}
 rdpu9_8 : Color
 rdpu9_8 =
-    rgb 73 0 106
+    rgb255 73 0 106
 
 
 {-| Provides the YlGnBu3 color scheme.
 -}
 ylgnbu3 : List Color
 ylgnbu3 =
-    [ rgb 237 248 177, rgb 127 205 187, rgb 44 127 184 ]
+    [ rgb255 237 248 177, rgb255 127 205 187, rgb255 44 127 184 ]
 
 
 {-| Provides the YlGnBu3-0 color.
 -}
 ylgnbu3_0 : Color
 ylgnbu3_0 =
-    rgb 237 248 177
+    rgb255 237 248 177
 
 
 {-| Provides the YlGnBu3-1 color.
 -}
 ylgnbu3_1 : Color
 ylgnbu3_1 =
-    rgb 127 205 187
+    rgb255 127 205 187
 
 
 {-| Provides the YlGnBu3-2 color.
 -}
 ylgnbu3_2 : Color
 ylgnbu3_2 =
-    rgb 44 127 184
+    rgb255 44 127 184
 
 
 {-| Provides the YlGnBu4 color scheme.
 -}
 ylgnbu4 : List Color
 ylgnbu4 =
-    [ rgb 255 255 204, rgb 161 218 180, rgb 65 182 196, rgb 34 94 168 ]
+    [ rgb255 255 255 204, rgb255 161 218 180, rgb255 65 182 196, rgb255 34 94 168 ]
 
 
 {-| Provides the YlGnBu4-0 color.
 -}
 ylgnbu4_0 : Color
 ylgnbu4_0 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the YlGnBu4-1 color.
 -}
 ylgnbu4_1 : Color
 ylgnbu4_1 =
-    rgb 161 218 180
+    rgb255 161 218 180
 
 
 {-| Provides the YlGnBu4-2 color.
 -}
 ylgnbu4_2 : Color
 ylgnbu4_2 =
-    rgb 65 182 196
+    rgb255 65 182 196
 
 
 {-| Provides the YlGnBu4-3 color.
 -}
 ylgnbu4_3 : Color
 ylgnbu4_3 =
-    rgb 34 94 168
+    rgb255 34 94 168
 
 
 {-| Provides the YlGnBu5 color scheme.
 -}
 ylgnbu5 : List Color
 ylgnbu5 =
-    [ rgb 255 255 204, rgb 161 218 180, rgb 65 182 196, rgb 44 127 184, rgb 37 52 148 ]
+    [ rgb255 255 255 204, rgb255 161 218 180, rgb255 65 182 196, rgb255 44 127 184, rgb255 37 52 148 ]
 
 
 {-| Provides the YlGnBu5-0 color.
 -}
 ylgnbu5_0 : Color
 ylgnbu5_0 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the YlGnBu5-1 color.
 -}
 ylgnbu5_1 : Color
 ylgnbu5_1 =
-    rgb 161 218 180
+    rgb255 161 218 180
 
 
 {-| Provides the YlGnBu5-2 color.
 -}
 ylgnbu5_2 : Color
 ylgnbu5_2 =
-    rgb 65 182 196
+    rgb255 65 182 196
 
 
 {-| Provides the YlGnBu5-3 color.
 -}
 ylgnbu5_3 : Color
 ylgnbu5_3 =
-    rgb 44 127 184
+    rgb255 44 127 184
 
 
 {-| Provides the YlGnBu5-4 color.
 -}
 ylgnbu5_4 : Color
 ylgnbu5_4 =
-    rgb 37 52 148
+    rgb255 37 52 148
 
 
 {-| Provides the YlGnBu6 color scheme.
 -}
 ylgnbu6 : List Color
 ylgnbu6 =
-    [ rgb 255 255 204, rgb 199 233 180, rgb 127 205 187, rgb 65 182 196, rgb 44 127 184, rgb 37 52 148 ]
+    [ rgb255 255 255 204, rgb255 199 233 180, rgb255 127 205 187, rgb255 65 182 196, rgb255 44 127 184, rgb255 37 52 148 ]
 
 
 {-| Provides the YlGnBu6-0 color.
 -}
 ylgnbu6_0 : Color
 ylgnbu6_0 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the YlGnBu6-1 color.
 -}
 ylgnbu6_1 : Color
 ylgnbu6_1 =
-    rgb 199 233 180
+    rgb255 199 233 180
 
 
 {-| Provides the YlGnBu6-2 color.
 -}
 ylgnbu6_2 : Color
 ylgnbu6_2 =
-    rgb 127 205 187
+    rgb255 127 205 187
 
 
 {-| Provides the YlGnBu6-3 color.
 -}
 ylgnbu6_3 : Color
 ylgnbu6_3 =
-    rgb 65 182 196
+    rgb255 65 182 196
 
 
 {-| Provides the YlGnBu6-4 color.
 -}
 ylgnbu6_4 : Color
 ylgnbu6_4 =
-    rgb 44 127 184
+    rgb255 44 127 184
 
 
 {-| Provides the YlGnBu6-5 color.
 -}
 ylgnbu6_5 : Color
 ylgnbu6_5 =
-    rgb 37 52 148
+    rgb255 37 52 148
 
 
 {-| Provides the YlGnBu7 color scheme.
 -}
 ylgnbu7 : List Color
 ylgnbu7 =
-    [ rgb 255 255 204, rgb 199 233 180, rgb 127 205 187, rgb 65 182 196, rgb 29 145 192, rgb 34 94 168, rgb 12 44 132 ]
+    [ rgb255 255 255 204, rgb255 199 233 180, rgb255 127 205 187, rgb255 65 182 196, rgb255 29 145 192, rgb255 34 94 168, rgb255 12 44 132 ]
 
 
 {-| Provides the YlGnBu7-0 color.
 -}
 ylgnbu7_0 : Color
 ylgnbu7_0 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the YlGnBu7-1 color.
 -}
 ylgnbu7_1 : Color
 ylgnbu7_1 =
-    rgb 199 233 180
+    rgb255 199 233 180
 
 
 {-| Provides the YlGnBu7-2 color.
 -}
 ylgnbu7_2 : Color
 ylgnbu7_2 =
-    rgb 127 205 187
+    rgb255 127 205 187
 
 
 {-| Provides the YlGnBu7-3 color.
 -}
 ylgnbu7_3 : Color
 ylgnbu7_3 =
-    rgb 65 182 196
+    rgb255 65 182 196
 
 
 {-| Provides the YlGnBu7-4 color.
 -}
 ylgnbu7_4 : Color
 ylgnbu7_4 =
-    rgb 29 145 192
+    rgb255 29 145 192
 
 
 {-| Provides the YlGnBu7-5 color.
 -}
 ylgnbu7_5 : Color
 ylgnbu7_5 =
-    rgb 34 94 168
+    rgb255 34 94 168
 
 
 {-| Provides the YlGnBu7-6 color.
 -}
 ylgnbu7_6 : Color
 ylgnbu7_6 =
-    rgb 12 44 132
+    rgb255 12 44 132
 
 
 {-| Provides the YlGnBu8 color scheme.
 -}
 ylgnbu8 : List Color
 ylgnbu8 =
-    [ rgb 255 255 217, rgb 237 248 177, rgb 199 233 180, rgb 127 205 187, rgb 65 182 196, rgb 29 145 192, rgb 34 94 168, rgb 12 44 132 ]
+    [ rgb255 255 255 217, rgb255 237 248 177, rgb255 199 233 180, rgb255 127 205 187, rgb255 65 182 196, rgb255 29 145 192, rgb255 34 94 168, rgb255 12 44 132 ]
 
 
 {-| Provides the YlGnBu8-0 color.
 -}
 ylgnbu8_0 : Color
 ylgnbu8_0 =
-    rgb 255 255 217
+    rgb255 255 255 217
 
 
 {-| Provides the YlGnBu8-1 color.
 -}
 ylgnbu8_1 : Color
 ylgnbu8_1 =
-    rgb 237 248 177
+    rgb255 237 248 177
 
 
 {-| Provides the YlGnBu8-2 color.
 -}
 ylgnbu8_2 : Color
 ylgnbu8_2 =
-    rgb 199 233 180
+    rgb255 199 233 180
 
 
 {-| Provides the YlGnBu8-3 color.
 -}
 ylgnbu8_3 : Color
 ylgnbu8_3 =
-    rgb 127 205 187
+    rgb255 127 205 187
 
 
 {-| Provides the YlGnBu8-4 color.
 -}
 ylgnbu8_4 : Color
 ylgnbu8_4 =
-    rgb 65 182 196
+    rgb255 65 182 196
 
 
 {-| Provides the YlGnBu8-5 color.
 -}
 ylgnbu8_5 : Color
 ylgnbu8_5 =
-    rgb 29 145 192
+    rgb255 29 145 192
 
 
 {-| Provides the YlGnBu8-6 color.
 -}
 ylgnbu8_6 : Color
 ylgnbu8_6 =
-    rgb 34 94 168
+    rgb255 34 94 168
 
 
 {-| Provides the YlGnBu8-7 color.
 -}
 ylgnbu8_7 : Color
 ylgnbu8_7 =
-    rgb 12 44 132
+    rgb255 12 44 132
 
 
 {-| Provides the YlGnBu9 color scheme.
 -}
 ylgnbu9 : List Color
 ylgnbu9 =
-    [ rgb 255 255 217, rgb 237 248 177, rgb 199 233 180, rgb 127 205 187, rgb 65 182 196, rgb 29 145 192, rgb 34 94 168, rgb 37 52 148, rgb 8 29 88 ]
+    [ rgb255 255 255 217, rgb255 237 248 177, rgb255 199 233 180, rgb255 127 205 187, rgb255 65 182 196, rgb255 29 145 192, rgb255 34 94 168, rgb255 37 52 148, rgb255 8 29 88 ]
 
 
 {-| Provides the YlGnBu9-0 color.
 -}
 ylgnbu9_0 : Color
 ylgnbu9_0 =
-    rgb 255 255 217
+    rgb255 255 255 217
 
 
 {-| Provides the YlGnBu9-1 color.
 -}
 ylgnbu9_1 : Color
 ylgnbu9_1 =
-    rgb 237 248 177
+    rgb255 237 248 177
 
 
 {-| Provides the YlGnBu9-2 color.
 -}
 ylgnbu9_2 : Color
 ylgnbu9_2 =
-    rgb 199 233 180
+    rgb255 199 233 180
 
 
 {-| Provides the YlGnBu9-3 color.
 -}
 ylgnbu9_3 : Color
 ylgnbu9_3 =
-    rgb 127 205 187
+    rgb255 127 205 187
 
 
 {-| Provides the YlGnBu9-4 color.
 -}
 ylgnbu9_4 : Color
 ylgnbu9_4 =
-    rgb 65 182 196
+    rgb255 65 182 196
 
 
 {-| Provides the YlGnBu9-5 color.
 -}
 ylgnbu9_5 : Color
 ylgnbu9_5 =
-    rgb 29 145 192
+    rgb255 29 145 192
 
 
 {-| Provides the YlGnBu9-6 color.
 -}
 ylgnbu9_6 : Color
 ylgnbu9_6 =
-    rgb 34 94 168
+    rgb255 34 94 168
 
 
 {-| Provides the YlGnBu9-7 color.
 -}
 ylgnbu9_7 : Color
 ylgnbu9_7 =
-    rgb 37 52 148
+    rgb255 37 52 148
 
 
 {-| Provides the YlGnBu9-8 color.
 -}
 ylgnbu9_8 : Color
 ylgnbu9_8 =
-    rgb 8 29 88
+    rgb255 8 29 88
 
 
 {-| Provides the GnBu3 color scheme.
 -}
 gnbu3 : List Color
 gnbu3 =
-    [ rgb 224 243 219, rgb 168 221 181, rgb 67 162 202 ]
+    [ rgb255 224 243 219, rgb255 168 221 181, rgb255 67 162 202 ]
 
 
 {-| Provides the GnBu3-0 color.
 -}
 gnbu3_0 : Color
 gnbu3_0 =
-    rgb 224 243 219
+    rgb255 224 243 219
 
 
 {-| Provides the GnBu3-1 color.
 -}
 gnbu3_1 : Color
 gnbu3_1 =
-    rgb 168 221 181
+    rgb255 168 221 181
 
 
 {-| Provides the GnBu3-2 color.
 -}
 gnbu3_2 : Color
 gnbu3_2 =
-    rgb 67 162 202
+    rgb255 67 162 202
 
 
 {-| Provides the GnBu4 color scheme.
 -}
 gnbu4 : List Color
 gnbu4 =
-    [ rgb 240 249 232, rgb 186 228 188, rgb 123 204 196, rgb 43 140 190 ]
+    [ rgb255 240 249 232, rgb255 186 228 188, rgb255 123 204 196, rgb255 43 140 190 ]
 
 
 {-| Provides the GnBu4-0 color.
 -}
 gnbu4_0 : Color
 gnbu4_0 =
-    rgb 240 249 232
+    rgb255 240 249 232
 
 
 {-| Provides the GnBu4-1 color.
 -}
 gnbu4_1 : Color
 gnbu4_1 =
-    rgb 186 228 188
+    rgb255 186 228 188
 
 
 {-| Provides the GnBu4-2 color.
 -}
 gnbu4_2 : Color
 gnbu4_2 =
-    rgb 123 204 196
+    rgb255 123 204 196
 
 
 {-| Provides the GnBu4-3 color.
 -}
 gnbu4_3 : Color
 gnbu4_3 =
-    rgb 43 140 190
+    rgb255 43 140 190
 
 
 {-| Provides the GnBu5 color scheme.
 -}
 gnbu5 : List Color
 gnbu5 =
-    [ rgb 240 249 232, rgb 186 228 188, rgb 123 204 196, rgb 67 162 202, rgb 8 104 172 ]
+    [ rgb255 240 249 232, rgb255 186 228 188, rgb255 123 204 196, rgb255 67 162 202, rgb255 8 104 172 ]
 
 
 {-| Provides the GnBu5-0 color.
 -}
 gnbu5_0 : Color
 gnbu5_0 =
-    rgb 240 249 232
+    rgb255 240 249 232
 
 
 {-| Provides the GnBu5-1 color.
 -}
 gnbu5_1 : Color
 gnbu5_1 =
-    rgb 186 228 188
+    rgb255 186 228 188
 
 
 {-| Provides the GnBu5-2 color.
 -}
 gnbu5_2 : Color
 gnbu5_2 =
-    rgb 123 204 196
+    rgb255 123 204 196
 
 
 {-| Provides the GnBu5-3 color.
 -}
 gnbu5_3 : Color
 gnbu5_3 =
-    rgb 67 162 202
+    rgb255 67 162 202
 
 
 {-| Provides the GnBu5-4 color.
 -}
 gnbu5_4 : Color
 gnbu5_4 =
-    rgb 8 104 172
+    rgb255 8 104 172
 
 
 {-| Provides the GnBu6 color scheme.
 -}
 gnbu6 : List Color
 gnbu6 =
-    [ rgb 240 249 232, rgb 204 235 197, rgb 168 221 181, rgb 123 204 196, rgb 67 162 202, rgb 8 104 172 ]
+    [ rgb255 240 249 232, rgb255 204 235 197, rgb255 168 221 181, rgb255 123 204 196, rgb255 67 162 202, rgb255 8 104 172 ]
 
 
 {-| Provides the GnBu6-0 color.
 -}
 gnbu6_0 : Color
 gnbu6_0 =
-    rgb 240 249 232
+    rgb255 240 249 232
 
 
 {-| Provides the GnBu6-1 color.
 -}
 gnbu6_1 : Color
 gnbu6_1 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the GnBu6-2 color.
 -}
 gnbu6_2 : Color
 gnbu6_2 =
-    rgb 168 221 181
+    rgb255 168 221 181
 
 
 {-| Provides the GnBu6-3 color.
 -}
 gnbu6_3 : Color
 gnbu6_3 =
-    rgb 123 204 196
+    rgb255 123 204 196
 
 
 {-| Provides the GnBu6-4 color.
 -}
 gnbu6_4 : Color
 gnbu6_4 =
-    rgb 67 162 202
+    rgb255 67 162 202
 
 
 {-| Provides the GnBu6-5 color.
 -}
 gnbu6_5 : Color
 gnbu6_5 =
-    rgb 8 104 172
+    rgb255 8 104 172
 
 
 {-| Provides the GnBu7 color scheme.
 -}
 gnbu7 : List Color
 gnbu7 =
-    [ rgb 240 249 232, rgb 204 235 197, rgb 168 221 181, rgb 123 204 196, rgb 78 179 211, rgb 43 140 190, rgb 8 88 158 ]
+    [ rgb255 240 249 232, rgb255 204 235 197, rgb255 168 221 181, rgb255 123 204 196, rgb255 78 179 211, rgb255 43 140 190, rgb255 8 88 158 ]
 
 
 {-| Provides the GnBu7-0 color.
 -}
 gnbu7_0 : Color
 gnbu7_0 =
-    rgb 240 249 232
+    rgb255 240 249 232
 
 
 {-| Provides the GnBu7-1 color.
 -}
 gnbu7_1 : Color
 gnbu7_1 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the GnBu7-2 color.
 -}
 gnbu7_2 : Color
 gnbu7_2 =
-    rgb 168 221 181
+    rgb255 168 221 181
 
 
 {-| Provides the GnBu7-3 color.
 -}
 gnbu7_3 : Color
 gnbu7_3 =
-    rgb 123 204 196
+    rgb255 123 204 196
 
 
 {-| Provides the GnBu7-4 color.
 -}
 gnbu7_4 : Color
 gnbu7_4 =
-    rgb 78 179 211
+    rgb255 78 179 211
 
 
 {-| Provides the GnBu7-5 color.
 -}
 gnbu7_5 : Color
 gnbu7_5 =
-    rgb 43 140 190
+    rgb255 43 140 190
 
 
 {-| Provides the GnBu7-6 color.
 -}
 gnbu7_6 : Color
 gnbu7_6 =
-    rgb 8 88 158
+    rgb255 8 88 158
 
 
 {-| Provides the GnBu8 color scheme.
 -}
 gnbu8 : List Color
 gnbu8 =
-    [ rgb 247 252 240, rgb 224 243 219, rgb 204 235 197, rgb 168 221 181, rgb 123 204 196, rgb 78 179 211, rgb 43 140 190, rgb 8 88 158 ]
+    [ rgb255 247 252 240, rgb255 224 243 219, rgb255 204 235 197, rgb255 168 221 181, rgb255 123 204 196, rgb255 78 179 211, rgb255 43 140 190, rgb255 8 88 158 ]
 
 
 {-| Provides the GnBu8-0 color.
 -}
 gnbu8_0 : Color
 gnbu8_0 =
-    rgb 247 252 240
+    rgb255 247 252 240
 
 
 {-| Provides the GnBu8-1 color.
 -}
 gnbu8_1 : Color
 gnbu8_1 =
-    rgb 224 243 219
+    rgb255 224 243 219
 
 
 {-| Provides the GnBu8-2 color.
 -}
 gnbu8_2 : Color
 gnbu8_2 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the GnBu8-3 color.
 -}
 gnbu8_3 : Color
 gnbu8_3 =
-    rgb 168 221 181
+    rgb255 168 221 181
 
 
 {-| Provides the GnBu8-4 color.
 -}
 gnbu8_4 : Color
 gnbu8_4 =
-    rgb 123 204 196
+    rgb255 123 204 196
 
 
 {-| Provides the GnBu8-5 color.
 -}
 gnbu8_5 : Color
 gnbu8_5 =
-    rgb 78 179 211
+    rgb255 78 179 211
 
 
 {-| Provides the GnBu8-6 color.
 -}
 gnbu8_6 : Color
 gnbu8_6 =
-    rgb 43 140 190
+    rgb255 43 140 190
 
 
 {-| Provides the GnBu8-7 color.
 -}
 gnbu8_7 : Color
 gnbu8_7 =
-    rgb 8 88 158
+    rgb255 8 88 158
 
 
 {-| Provides the GnBu9 color scheme.
 -}
 gnbu9 : List Color
 gnbu9 =
-    [ rgb 247 252 240, rgb 224 243 219, rgb 204 235 197, rgb 168 221 181, rgb 123 204 196, rgb 78 179 211, rgb 43 140 190, rgb 8 104 172, rgb 8 64 129 ]
+    [ rgb255 247 252 240, rgb255 224 243 219, rgb255 204 235 197, rgb255 168 221 181, rgb255 123 204 196, rgb255 78 179 211, rgb255 43 140 190, rgb255 8 104 172, rgb255 8 64 129 ]
 
 
 {-| Provides the GnBu9-0 color.
 -}
 gnbu9_0 : Color
 gnbu9_0 =
-    rgb 247 252 240
+    rgb255 247 252 240
 
 
 {-| Provides the GnBu9-1 color.
 -}
 gnbu9_1 : Color
 gnbu9_1 =
-    rgb 224 243 219
+    rgb255 224 243 219
 
 
 {-| Provides the GnBu9-2 color.
 -}
 gnbu9_2 : Color
 gnbu9_2 =
-    rgb 204 235 197
+    rgb255 204 235 197
 
 
 {-| Provides the GnBu9-3 color.
 -}
 gnbu9_3 : Color
 gnbu9_3 =
-    rgb 168 221 181
+    rgb255 168 221 181
 
 
 {-| Provides the GnBu9-4 color.
 -}
 gnbu9_4 : Color
 gnbu9_4 =
-    rgb 123 204 196
+    rgb255 123 204 196
 
 
 {-| Provides the GnBu9-5 color.
 -}
 gnbu9_5 : Color
 gnbu9_5 =
-    rgb 78 179 211
+    rgb255 78 179 211
 
 
 {-| Provides the GnBu9-6 color.
 -}
 gnbu9_6 : Color
 gnbu9_6 =
-    rgb 43 140 190
+    rgb255 43 140 190
 
 
 {-| Provides the GnBu9-7 color.
 -}
 gnbu9_7 : Color
 gnbu9_7 =
-    rgb 8 104 172
+    rgb255 8 104 172
 
 
 {-| Provides the GnBu9-8 color.
 -}
 gnbu9_8 : Color
 gnbu9_8 =
-    rgb 8 64 129
+    rgb255 8 64 129
 
 
 {-| Provides the YlOrRd3 color scheme.
 -}
 ylorrd3 : List Color
 ylorrd3 =
-    [ rgb 255 237 160, rgb 254 178 76, rgb 240 59 32 ]
+    [ rgb255 255 237 160, rgb255 254 178 76, rgb255 240 59 32 ]
 
 
 {-| Provides the YlOrRd3-0 color.
 -}
 ylorrd3_0 : Color
 ylorrd3_0 =
-    rgb 255 237 160
+    rgb255 255 237 160
 
 
 {-| Provides the YlOrRd3-1 color.
 -}
 ylorrd3_1 : Color
 ylorrd3_1 =
-    rgb 254 178 76
+    rgb255 254 178 76
 
 
 {-| Provides the YlOrRd3-2 color.
 -}
 ylorrd3_2 : Color
 ylorrd3_2 =
-    rgb 240 59 32
+    rgb255 240 59 32
 
 
 {-| Provides the YlOrRd4 color scheme.
 -}
 ylorrd4 : List Color
 ylorrd4 =
-    [ rgb 255 255 178, rgb 254 204 92, rgb 253 141 60, rgb 227 26 28 ]
+    [ rgb255 255 255 178, rgb255 254 204 92, rgb255 253 141 60, rgb255 227 26 28 ]
 
 
 {-| Provides the YlOrRd4-0 color.
 -}
 ylorrd4_0 : Color
 ylorrd4_0 =
-    rgb 255 255 178
+    rgb255 255 255 178
 
 
 {-| Provides the YlOrRd4-1 color.
 -}
 ylorrd4_1 : Color
 ylorrd4_1 =
-    rgb 254 204 92
+    rgb255 254 204 92
 
 
 {-| Provides the YlOrRd4-2 color.
 -}
 ylorrd4_2 : Color
 ylorrd4_2 =
-    rgb 253 141 60
+    rgb255 253 141 60
 
 
 {-| Provides the YlOrRd4-3 color.
 -}
 ylorrd4_3 : Color
 ylorrd4_3 =
-    rgb 227 26 28
+    rgb255 227 26 28
 
 
 {-| Provides the YlOrRd5 color scheme.
 -}
 ylorrd5 : List Color
 ylorrd5 =
-    [ rgb 255 255 178, rgb 254 204 92, rgb 253 141 60, rgb 240 59 32, rgb 189 0 38 ]
+    [ rgb255 255 255 178, rgb255 254 204 92, rgb255 253 141 60, rgb255 240 59 32, rgb255 189 0 38 ]
 
 
 {-| Provides the YlOrRd5-0 color.
 -}
 ylorrd5_0 : Color
 ylorrd5_0 =
-    rgb 255 255 178
+    rgb255 255 255 178
 
 
 {-| Provides the YlOrRd5-1 color.
 -}
 ylorrd5_1 : Color
 ylorrd5_1 =
-    rgb 254 204 92
+    rgb255 254 204 92
 
 
 {-| Provides the YlOrRd5-2 color.
 -}
 ylorrd5_2 : Color
 ylorrd5_2 =
-    rgb 253 141 60
+    rgb255 253 141 60
 
 
 {-| Provides the YlOrRd5-3 color.
 -}
 ylorrd5_3 : Color
 ylorrd5_3 =
-    rgb 240 59 32
+    rgb255 240 59 32
 
 
 {-| Provides the YlOrRd5-4 color.
 -}
 ylorrd5_4 : Color
 ylorrd5_4 =
-    rgb 189 0 38
+    rgb255 189 0 38
 
 
 {-| Provides the YlOrRd6 color scheme.
 -}
 ylorrd6 : List Color
 ylorrd6 =
-    [ rgb 255 255 178, rgb 254 217 118, rgb 254 178 76, rgb 253 141 60, rgb 240 59 32, rgb 189 0 38 ]
+    [ rgb255 255 255 178, rgb255 254 217 118, rgb255 254 178 76, rgb255 253 141 60, rgb255 240 59 32, rgb255 189 0 38 ]
 
 
 {-| Provides the YlOrRd6-0 color.
 -}
 ylorrd6_0 : Color
 ylorrd6_0 =
-    rgb 255 255 178
+    rgb255 255 255 178
 
 
 {-| Provides the YlOrRd6-1 color.
 -}
 ylorrd6_1 : Color
 ylorrd6_1 =
-    rgb 254 217 118
+    rgb255 254 217 118
 
 
 {-| Provides the YlOrRd6-2 color.
 -}
 ylorrd6_2 : Color
 ylorrd6_2 =
-    rgb 254 178 76
+    rgb255 254 178 76
 
 
 {-| Provides the YlOrRd6-3 color.
 -}
 ylorrd6_3 : Color
 ylorrd6_3 =
-    rgb 253 141 60
+    rgb255 253 141 60
 
 
 {-| Provides the YlOrRd6-4 color.
 -}
 ylorrd6_4 : Color
 ylorrd6_4 =
-    rgb 240 59 32
+    rgb255 240 59 32
 
 
 {-| Provides the YlOrRd6-5 color.
 -}
 ylorrd6_5 : Color
 ylorrd6_5 =
-    rgb 189 0 38
+    rgb255 189 0 38
 
 
 {-| Provides the YlOrRd7 color scheme.
 -}
 ylorrd7 : List Color
 ylorrd7 =
-    [ rgb 255 255 178, rgb 254 217 118, rgb 254 178 76, rgb 253 141 60, rgb 252 78 42, rgb 227 26 28, rgb 177 0 38 ]
+    [ rgb255 255 255 178, rgb255 254 217 118, rgb255 254 178 76, rgb255 253 141 60, rgb255 252 78 42, rgb255 227 26 28, rgb255 177 0 38 ]
 
 
 {-| Provides the YlOrRd7-0 color.
 -}
 ylorrd7_0 : Color
 ylorrd7_0 =
-    rgb 255 255 178
+    rgb255 255 255 178
 
 
 {-| Provides the YlOrRd7-1 color.
 -}
 ylorrd7_1 : Color
 ylorrd7_1 =
-    rgb 254 217 118
+    rgb255 254 217 118
 
 
 {-| Provides the YlOrRd7-2 color.
 -}
 ylorrd7_2 : Color
 ylorrd7_2 =
-    rgb 254 178 76
+    rgb255 254 178 76
 
 
 {-| Provides the YlOrRd7-3 color.
 -}
 ylorrd7_3 : Color
 ylorrd7_3 =
-    rgb 253 141 60
+    rgb255 253 141 60
 
 
 {-| Provides the YlOrRd7-4 color.
 -}
 ylorrd7_4 : Color
 ylorrd7_4 =
-    rgb 252 78 42
+    rgb255 252 78 42
 
 
 {-| Provides the YlOrRd7-5 color.
 -}
 ylorrd7_5 : Color
 ylorrd7_5 =
-    rgb 227 26 28
+    rgb255 227 26 28
 
 
 {-| Provides the YlOrRd7-6 color.
 -}
 ylorrd7_6 : Color
 ylorrd7_6 =
-    rgb 177 0 38
+    rgb255 177 0 38
 
 
 {-| Provides the YlOrRd8 color scheme.
 -}
 ylorrd8 : List Color
 ylorrd8 =
-    [ rgb 255 255 204, rgb 255 237 160, rgb 254 217 118, rgb 254 178 76, rgb 253 141 60, rgb 252 78 42, rgb 227 26 28, rgb 177 0 38 ]
+    [ rgb255 255 255 204, rgb255 255 237 160, rgb255 254 217 118, rgb255 254 178 76, rgb255 253 141 60, rgb255 252 78 42, rgb255 227 26 28, rgb255 177 0 38 ]
 
 
 {-| Provides the YlOrRd8-0 color.
 -}
 ylorrd8_0 : Color
 ylorrd8_0 =
-    rgb 255 255 204
+    rgb255 255 255 204
 
 
 {-| Provides the YlOrRd8-1 color.
 -}
 ylorrd8_1 : Color
 ylorrd8_1 =
-    rgb 255 237 160
+    rgb255 255 237 160
 
 
 {-| Provides the YlOrRd8-2 color.
 -}
 ylorrd8_2 : Color
 ylorrd8_2 =
-    rgb 254 217 118
+    rgb255 254 217 118
 
 
 {-| Provides the YlOrRd8-3 color.
 -}
 ylorrd8_3 : Color
 ylorrd8_3 =
-    rgb 254 178 76
+    rgb255 254 178 76
 
 
 {-| Provides the YlOrRd8-4 color.
 -}
 ylorrd8_4 : Color
 ylorrd8_4 =
-    rgb 253 141 60
+    rgb255 253 141 60
 
 
 {-| Provides the YlOrRd8-5 color.
 -}
 ylorrd8_5 : Color
 ylorrd8_5 =
-    rgb 252 78 42
+    rgb255 252 78 42
 
 
 {-| Provides the YlOrRd8-6 color.
 -}
 ylorrd8_6 : Color
 ylorrd8_6 =
-    rgb 227 26 28
+    rgb255 227 26 28
 
 
 {-| Provides the YlOrRd8-7 color.
 -}
 ylorrd8_7 : Color
 ylorrd8_7 =
-    rgb 177 0 38
+    rgb255 177 0 38
 
 
 {-| Provides the PuRd3 color scheme.
 -}
 purd3 : List Color
 purd3 =
-    [ rgb 231 225 239, rgb 201 148 199, rgb 221 28 119 ]
+    [ rgb255 231 225 239, rgb255 201 148 199, rgb255 221 28 119 ]
 
 
 {-| Provides the PuRd3-0 color.
 -}
 purd3_0 : Color
 purd3_0 =
-    rgb 231 225 239
+    rgb255 231 225 239
 
 
 {-| Provides the PuRd3-1 color.
 -}
 purd3_1 : Color
 purd3_1 =
-    rgb 201 148 199
+    rgb255 201 148 199
 
 
 {-| Provides the PuRd3-2 color.
 -}
 purd3_2 : Color
 purd3_2 =
-    rgb 221 28 119
+    rgb255 221 28 119
 
 
 {-| Provides the PuRd4 color scheme.
 -}
 purd4 : List Color
 purd4 =
-    [ rgb 241 238 246, rgb 215 181 216, rgb 223 101 176, rgb 206 18 86 ]
+    [ rgb255 241 238 246, rgb255 215 181 216, rgb255 223 101 176, rgb255 206 18 86 ]
 
 
 {-| Provides the PuRd4-0 color.
 -}
 purd4_0 : Color
 purd4_0 =
-    rgb 241 238 246
+    rgb255 241 238 246
 
 
 {-| Provides the PuRd4-1 color.
 -}
 purd4_1 : Color
 purd4_1 =
-    rgb 215 181 216
+    rgb255 215 181 216
 
 
 {-| Provides the PuRd4-2 color.
 -}
 purd4_2 : Color
 purd4_2 =
-    rgb 223 101 176
+    rgb255 223 101 176
 
 
 {-| Provides the PuRd4-3 color.
 -}
 purd4_3 : Color
 purd4_3 =
-    rgb 206 18 86
+    rgb255 206 18 86
 
 
 {-| Provides the PuRd5 color scheme.
 -}
 purd5 : List Color
 purd5 =
-    [ rgb 241 238 246, rgb 215 181 216, rgb 223 101 176, rgb 221 28 119, rgb 152 0 67 ]
+    [ rgb255 241 238 246, rgb255 215 181 216, rgb255 223 101 176, rgb255 221 28 119, rgb255 152 0 67 ]
 
 
 {-| Provides the PuRd5-0 color.
 -}
 purd5_0 : Color
 purd5_0 =
-    rgb 241 238 246
+    rgb255 241 238 246
 
 
 {-| Provides the PuRd5-1 color.
 -}
 purd5_1 : Color
 purd5_1 =
-    rgb 215 181 216
+    rgb255 215 181 216
 
 
 {-| Provides the PuRd5-2 color.
 -}
 purd5_2 : Color
 purd5_2 =
-    rgb 223 101 176
+    rgb255 223 101 176
 
 
 {-| Provides the PuRd5-3 color.
 -}
 purd5_3 : Color
 purd5_3 =
-    rgb 221 28 119
+    rgb255 221 28 119
 
 
 {-| Provides the PuRd5-4 color.
 -}
 purd5_4 : Color
 purd5_4 =
-    rgb 152 0 67
+    rgb255 152 0 67
 
 
 {-| Provides the PuRd6 color scheme.
 -}
 purd6 : List Color
 purd6 =
-    [ rgb 241 238 246, rgb 212 185 218, rgb 201 148 199, rgb 223 101 176, rgb 221 28 119, rgb 152 0 67 ]
+    [ rgb255 241 238 246, rgb255 212 185 218, rgb255 201 148 199, rgb255 223 101 176, rgb255 221 28 119, rgb255 152 0 67 ]
 
 
 {-| Provides the PuRd6-0 color.
 -}
 purd6_0 : Color
 purd6_0 =
-    rgb 241 238 246
+    rgb255 241 238 246
 
 
 {-| Provides the PuRd6-1 color.
 -}
 purd6_1 : Color
 purd6_1 =
-    rgb 212 185 218
+    rgb255 212 185 218
 
 
 {-| Provides the PuRd6-2 color.
 -}
 purd6_2 : Color
 purd6_2 =
-    rgb 201 148 199
+    rgb255 201 148 199
 
 
 {-| Provides the PuRd6-3 color.
 -}
 purd6_3 : Color
 purd6_3 =
-    rgb 223 101 176
+    rgb255 223 101 176
 
 
 {-| Provides the PuRd6-4 color.
 -}
 purd6_4 : Color
 purd6_4 =
-    rgb 221 28 119
+    rgb255 221 28 119
 
 
 {-| Provides the PuRd6-5 color.
 -}
 purd6_5 : Color
 purd6_5 =
-    rgb 152 0 67
+    rgb255 152 0 67
 
 
 {-| Provides the PuRd7 color scheme.
 -}
 purd7 : List Color
 purd7 =
-    [ rgb 241 238 246, rgb 212 185 218, rgb 201 148 199, rgb 223 101 176, rgb 231 41 138, rgb 206 18 86, rgb 145 0 63 ]
+    [ rgb255 241 238 246, rgb255 212 185 218, rgb255 201 148 199, rgb255 223 101 176, rgb255 231 41 138, rgb255 206 18 86, rgb255 145 0 63 ]
 
 
 {-| Provides the PuRd7-0 color.
 -}
 purd7_0 : Color
 purd7_0 =
-    rgb 241 238 246
+    rgb255 241 238 246
 
 
 {-| Provides the PuRd7-1 color.
 -}
 purd7_1 : Color
 purd7_1 =
-    rgb 212 185 218
+    rgb255 212 185 218
 
 
 {-| Provides the PuRd7-2 color.
 -}
 purd7_2 : Color
 purd7_2 =
-    rgb 201 148 199
+    rgb255 201 148 199
 
 
 {-| Provides the PuRd7-3 color.
 -}
 purd7_3 : Color
 purd7_3 =
-    rgb 223 101 176
+    rgb255 223 101 176
 
 
 {-| Provides the PuRd7-4 color.
 -}
 purd7_4 : Color
 purd7_4 =
-    rgb 231 41 138
+    rgb255 231 41 138
 
 
 {-| Provides the PuRd7-5 color.
 -}
 purd7_5 : Color
 purd7_5 =
-    rgb 206 18 86
+    rgb255 206 18 86
 
 
 {-| Provides the PuRd7-6 color.
 -}
 purd7_6 : Color
 purd7_6 =
-    rgb 145 0 63
+    rgb255 145 0 63
 
 
 {-| Provides the PuRd8 color scheme.
 -}
 purd8 : List Color
 purd8 =
-    [ rgb 247 244 249, rgb 231 225 239, rgb 212 185 218, rgb 201 148 199, rgb 223 101 176, rgb 231 41 138, rgb 206 18 86, rgb 145 0 63 ]
+    [ rgb255 247 244 249, rgb255 231 225 239, rgb255 212 185 218, rgb255 201 148 199, rgb255 223 101 176, rgb255 231 41 138, rgb255 206 18 86, rgb255 145 0 63 ]
 
 
 {-| Provides the PuRd8-0 color.
 -}
 purd8_0 : Color
 purd8_0 =
-    rgb 247 244 249
+    rgb255 247 244 249
 
 
 {-| Provides the PuRd8-1 color.
 -}
 purd8_1 : Color
 purd8_1 =
-    rgb 231 225 239
+    rgb255 231 225 239
 
 
 {-| Provides the PuRd8-2 color.
 -}
 purd8_2 : Color
 purd8_2 =
-    rgb 212 185 218
+    rgb255 212 185 218
 
 
 {-| Provides the PuRd8-3 color.
 -}
 purd8_3 : Color
 purd8_3 =
-    rgb 201 148 199
+    rgb255 201 148 199
 
 
 {-| Provides the PuRd8-4 color.
 -}
 purd8_4 : Color
 purd8_4 =
-    rgb 223 101 176
+    rgb255 223 101 176
 
 
 {-| Provides the PuRd8-5 color.
 -}
 purd8_5 : Color
 purd8_5 =
-    rgb 231 41 138
+    rgb255 231 41 138
 
 
 {-| Provides the PuRd8-6 color.
 -}
 purd8_6 : Color
 purd8_6 =
-    rgb 206 18 86
+    rgb255 206 18 86
 
 
 {-| Provides the PuRd8-7 color.
 -}
 purd8_7 : Color
 purd8_7 =
-    rgb 145 0 63
+    rgb255 145 0 63
 
 
 {-| Provides the PuRd9 color scheme.
 -}
 purd9 : List Color
 purd9 =
-    [ rgb 247 244 249, rgb 231 225 239, rgb 212 185 218, rgb 201 148 199, rgb 223 101 176, rgb 231 41 138, rgb 206 18 86, rgb 152 0 67, rgb 103 0 31 ]
+    [ rgb255 247 244 249, rgb255 231 225 239, rgb255 212 185 218, rgb255 201 148 199, rgb255 223 101 176, rgb255 231 41 138, rgb255 206 18 86, rgb255 152 0 67, rgb255 103 0 31 ]
 
 
 {-| Provides the PuRd9-0 color.
 -}
 purd9_0 : Color
 purd9_0 =
-    rgb 247 244 249
+    rgb255 247 244 249
 
 
 {-| Provides the PuRd9-1 color.
 -}
 purd9_1 : Color
 purd9_1 =
-    rgb 231 225 239
+    rgb255 231 225 239
 
 
 {-| Provides the PuRd9-2 color.
 -}
 purd9_2 : Color
 purd9_2 =
-    rgb 212 185 218
+    rgb255 212 185 218
 
 
 {-| Provides the PuRd9-3 color.
 -}
 purd9_3 : Color
 purd9_3 =
-    rgb 201 148 199
+    rgb255 201 148 199
 
 
 {-| Provides the PuRd9-4 color.
 -}
 purd9_4 : Color
 purd9_4 =
-    rgb 223 101 176
+    rgb255 223 101 176
 
 
 {-| Provides the PuRd9-5 color.
 -}
 purd9_5 : Color
 purd9_5 =
-    rgb 231 41 138
+    rgb255 231 41 138
 
 
 {-| Provides the PuRd9-6 color.
 -}
 purd9_6 : Color
 purd9_6 =
-    rgb 206 18 86
+    rgb255 206 18 86
 
 
 {-| Provides the PuRd9-7 color.
 -}
 purd9_7 : Color
 purd9_7 =
-    rgb 152 0 67
+    rgb255 152 0 67
 
 
 {-| Provides the PuRd9-8 color.
 -}
 purd9_8 : Color
 purd9_8 =
-    rgb 103 0 31
+    rgb255 103 0 31
 
 
 {-| Provides the PuBuGn3 color scheme.
 -}
 pubugn3 : List Color
 pubugn3 =
-    [ rgb 236 226 240, rgb 166 189 219, rgb 28 144 153 ]
+    [ rgb255 236 226 240, rgb255 166 189 219, rgb255 28 144 153 ]
 
 
 {-| Provides the PuBuGn3-0 color.
 -}
 pubugn3_0 : Color
 pubugn3_0 =
-    rgb 236 226 240
+    rgb255 236 226 240
 
 
 {-| Provides the PuBuGn3-1 color.
 -}
 pubugn3_1 : Color
 pubugn3_1 =
-    rgb 166 189 219
+    rgb255 166 189 219
 
 
 {-| Provides the PuBuGn3-2 color.
 -}
 pubugn3_2 : Color
 pubugn3_2 =
-    rgb 28 144 153
+    rgb255 28 144 153
 
 
 {-| Provides the PuBuGn4 color scheme.
 -}
 pubugn4 : List Color
 pubugn4 =
-    [ rgb 246 239 247, rgb 189 201 225, rgb 103 169 207, rgb 2 129 138 ]
+    [ rgb255 246 239 247, rgb255 189 201 225, rgb255 103 169 207, rgb255 2 129 138 ]
 
 
 {-| Provides the PuBuGn4-0 color.
 -}
 pubugn4_0 : Color
 pubugn4_0 =
-    rgb 246 239 247
+    rgb255 246 239 247
 
 
 {-| Provides the PuBuGn4-1 color.
 -}
 pubugn4_1 : Color
 pubugn4_1 =
-    rgb 189 201 225
+    rgb255 189 201 225
 
 
 {-| Provides the PuBuGn4-2 color.
 -}
 pubugn4_2 : Color
 pubugn4_2 =
-    rgb 103 169 207
+    rgb255 103 169 207
 
 
 {-| Provides the PuBuGn4-3 color.
 -}
 pubugn4_3 : Color
 pubugn4_3 =
-    rgb 2 129 138
+    rgb255 2 129 138
 
 
 {-| Provides the PuBuGn5 color scheme.
 -}
 pubugn5 : List Color
 pubugn5 =
-    [ rgb 246 239 247, rgb 189 201 225, rgb 103 169 207, rgb 28 144 153, rgb 1 108 89 ]
+    [ rgb255 246 239 247, rgb255 189 201 225, rgb255 103 169 207, rgb255 28 144 153, rgb255 1 108 89 ]
 
 
 {-| Provides the PuBuGn5-0 color.
 -}
 pubugn5_0 : Color
 pubugn5_0 =
-    rgb 246 239 247
+    rgb255 246 239 247
 
 
 {-| Provides the PuBuGn5-1 color.
 -}
 pubugn5_1 : Color
 pubugn5_1 =
-    rgb 189 201 225
+    rgb255 189 201 225
 
 
 {-| Provides the PuBuGn5-2 color.
 -}
 pubugn5_2 : Color
 pubugn5_2 =
-    rgb 103 169 207
+    rgb255 103 169 207
 
 
 {-| Provides the PuBuGn5-3 color.
 -}
 pubugn5_3 : Color
 pubugn5_3 =
-    rgb 28 144 153
+    rgb255 28 144 153
 
 
 {-| Provides the PuBuGn5-4 color.
 -}
 pubugn5_4 : Color
 pubugn5_4 =
-    rgb 1 108 89
+    rgb255 1 108 89
 
 
 {-| Provides the PuBuGn6 color scheme.
 -}
 pubugn6 : List Color
 pubugn6 =
-    [ rgb 246 239 247, rgb 208 209 230, rgb 166 189 219, rgb 103 169 207, rgb 28 144 153, rgb 1 108 89 ]
+    [ rgb255 246 239 247, rgb255 208 209 230, rgb255 166 189 219, rgb255 103 169 207, rgb255 28 144 153, rgb255 1 108 89 ]
 
 
 {-| Provides the PuBuGn6-0 color.
 -}
 pubugn6_0 : Color
 pubugn6_0 =
-    rgb 246 239 247
+    rgb255 246 239 247
 
 
 {-| Provides the PuBuGn6-1 color.
 -}
 pubugn6_1 : Color
 pubugn6_1 =
-    rgb 208 209 230
+    rgb255 208 209 230
 
 
 {-| Provides the PuBuGn6-2 color.
 -}
 pubugn6_2 : Color
 pubugn6_2 =
-    rgb 166 189 219
+    rgb255 166 189 219
 
 
 {-| Provides the PuBuGn6-3 color.
 -}
 pubugn6_3 : Color
 pubugn6_3 =
-    rgb 103 169 207
+    rgb255 103 169 207
 
 
 {-| Provides the PuBuGn6-4 color.
 -}
 pubugn6_4 : Color
 pubugn6_4 =
-    rgb 28 144 153
+    rgb255 28 144 153
 
 
 {-| Provides the PuBuGn6-5 color.
 -}
 pubugn6_5 : Color
 pubugn6_5 =
-    rgb 1 108 89
+    rgb255 1 108 89
 
 
 {-| Provides the PuBuGn7 color scheme.
 -}
 pubugn7 : List Color
 pubugn7 =
-    [ rgb 246 239 247, rgb 208 209 230, rgb 166 189 219, rgb 103 169 207, rgb 54 144 192, rgb 2 129 138, rgb 1 100 80 ]
+    [ rgb255 246 239 247, rgb255 208 209 230, rgb255 166 189 219, rgb255 103 169 207, rgb255 54 144 192, rgb255 2 129 138, rgb255 1 100 80 ]
 
 
 {-| Provides the PuBuGn7-0 color.
 -}
 pubugn7_0 : Color
 pubugn7_0 =
-    rgb 246 239 247
+    rgb255 246 239 247
 
 
 {-| Provides the PuBuGn7-1 color.
 -}
 pubugn7_1 : Color
 pubugn7_1 =
-    rgb 208 209 230
+    rgb255 208 209 230
 
 
 {-| Provides the PuBuGn7-2 color.
 -}
 pubugn7_2 : Color
 pubugn7_2 =
-    rgb 166 189 219
+    rgb255 166 189 219
 
 
 {-| Provides the PuBuGn7-3 color.
 -}
 pubugn7_3 : Color
 pubugn7_3 =
-    rgb 103 169 207
+    rgb255 103 169 207
 
 
 {-| Provides the PuBuGn7-4 color.
 -}
 pubugn7_4 : Color
 pubugn7_4 =
-    rgb 54 144 192
+    rgb255 54 144 192
 
 
 {-| Provides the PuBuGn7-5 color.
 -}
 pubugn7_5 : Color
 pubugn7_5 =
-    rgb 2 129 138
+    rgb255 2 129 138
 
 
 {-| Provides the PuBuGn7-6 color.
 -}
 pubugn7_6 : Color
 pubugn7_6 =
-    rgb 1 100 80
+    rgb255 1 100 80
 
 
 {-| Provides the PuBuGn8 color scheme.
 -}
 pubugn8 : List Color
 pubugn8 =
-    [ rgb 255 247 251, rgb 236 226 240, rgb 208 209 230, rgb 166 189 219, rgb 103 169 207, rgb 54 144 192, rgb 2 129 138, rgb 1 100 80 ]
+    [ rgb255 255 247 251, rgb255 236 226 240, rgb255 208 209 230, rgb255 166 189 219, rgb255 103 169 207, rgb255 54 144 192, rgb255 2 129 138, rgb255 1 100 80 ]
 
 
 {-| Provides the PuBuGn8-0 color.
 -}
 pubugn8_0 : Color
 pubugn8_0 =
-    rgb 255 247 251
+    rgb255 255 247 251
 
 
 {-| Provides the PuBuGn8-1 color.
 -}
 pubugn8_1 : Color
 pubugn8_1 =
-    rgb 236 226 240
+    rgb255 236 226 240
 
 
 {-| Provides the PuBuGn8-2 color.
 -}
 pubugn8_2 : Color
 pubugn8_2 =
-    rgb 208 209 230
+    rgb255 208 209 230
 
 
 {-| Provides the PuBuGn8-3 color.
 -}
 pubugn8_3 : Color
 pubugn8_3 =
-    rgb 166 189 219
+    rgb255 166 189 219
 
 
 {-| Provides the PuBuGn8-4 color.
 -}
 pubugn8_4 : Color
 pubugn8_4 =
-    rgb 103 169 207
+    rgb255 103 169 207
 
 
 {-| Provides the PuBuGn8-5 color.
 -}
 pubugn8_5 : Color
 pubugn8_5 =
-    rgb 54 144 192
+    rgb255 54 144 192
 
 
 {-| Provides the PuBuGn8-6 color.
 -}
 pubugn8_6 : Color
 pubugn8_6 =
-    rgb 2 129 138
+    rgb255 2 129 138
 
 
 {-| Provides the PuBuGn8-7 color.
 -}
 pubugn8_7 : Color
 pubugn8_7 =
-    rgb 1 100 80
+    rgb255 1 100 80
 
 
 {-| Provides the PuBuGn9 color scheme.
 -}
 pubugn9 : List Color
 pubugn9 =
-    [ rgb 255 247 251, rgb 236 226 240, rgb 208 209 230, rgb 166 189 219, rgb 103 169 207, rgb 54 144 192, rgb 2 129 138, rgb 1 108 89, rgb 1 70 54 ]
+    [ rgb255 255 247 251, rgb255 236 226 240, rgb255 208 209 230, rgb255 166 189 219, rgb255 103 169 207, rgb255 54 144 192, rgb255 2 129 138, rgb255 1 108 89, rgb255 1 70 54 ]
 
 
 {-| Provides the PuBuGn9-0 color.
 -}
 pubugn9_0 : Color
 pubugn9_0 =
-    rgb 255 247 251
+    rgb255 255 247 251
 
 
 {-| Provides the PuBuGn9-1 color.
 -}
 pubugn9_1 : Color
 pubugn9_1 =
-    rgb 236 226 240
+    rgb255 236 226 240
 
 
 {-| Provides the PuBuGn9-2 color.
 -}
 pubugn9_2 : Color
 pubugn9_2 =
-    rgb 208 209 230
+    rgb255 208 209 230
 
 
 {-| Provides the PuBuGn9-3 color.
 -}
 pubugn9_3 : Color
 pubugn9_3 =
-    rgb 166 189 219
+    rgb255 166 189 219
 
 
 {-| Provides the PuBuGn9-4 color.
 -}
 pubugn9_4 : Color
 pubugn9_4 =
-    rgb 103 169 207
+    rgb255 103 169 207
 
 
 {-| Provides the PuBuGn9-5 color.
 -}
 pubugn9_5 : Color
 pubugn9_5 =
-    rgb 54 144 192
+    rgb255 54 144 192
 
 
 {-| Provides the PuBuGn9-6 color.
 -}
 pubugn9_6 : Color
 pubugn9_6 =
-    rgb 2 129 138
+    rgb255 2 129 138
 
 
 {-| Provides the PuBuGn9-7 color.
 -}
 pubugn9_7 : Color
 pubugn9_7 =
-    rgb 1 108 89
+    rgb255 1 108 89
 
 
 {-| Provides the PuBuGn9-8 color.
 -}
 pubugn9_8 : Color
 pubugn9_8 =
-    rgb 1 70 54
+    rgb255 1 70 54
 
 
 {-| Returns a OrRd color scheme.
@@ -4064,10 +4064,10 @@ orrd n =
             []
 
         1 ->
-            [ rgb 254 232 200 ]
+            [ rgb255 254 232 200 ]
 
         2 ->
-            [ rgb 254 232 200, rgb 253 187 132 ]
+            [ rgb255 254 232 200, rgb255 253 187 132 ]
 
         3 ->
             orrd3
@@ -4100,10 +4100,10 @@ pubu n =
             []
 
         1 ->
-            [ rgb 236 231 242 ]
+            [ rgb255 236 231 242 ]
 
         2 ->
-            [ rgb 236 231 242, rgb 166 189 219 ]
+            [ rgb255 236 231 242, rgb255 166 189 219 ]
 
         3 ->
             pubu3
@@ -4136,10 +4136,10 @@ bupu n =
             []
 
         1 ->
-            [ rgb 224 236 244 ]
+            [ rgb255 224 236 244 ]
 
         2 ->
-            [ rgb 224 236 244, rgb 158 188 218 ]
+            [ rgb255 224 236 244, rgb255 158 188 218 ]
 
         3 ->
             bupu3
@@ -4172,10 +4172,10 @@ bugn n =
             []
 
         1 ->
-            [ rgb 229 245 249 ]
+            [ rgb255 229 245 249 ]
 
         2 ->
-            [ rgb 229 245 249, rgb 153 216 201 ]
+            [ rgb255 229 245 249, rgb255 153 216 201 ]
 
         3 ->
             bugn3
@@ -4208,10 +4208,10 @@ ylorbr n =
             []
 
         1 ->
-            [ rgb 255 247 188 ]
+            [ rgb255 255 247 188 ]
 
         2 ->
-            [ rgb 255 247 188, rgb 254 196 79 ]
+            [ rgb255 255 247 188, rgb255 254 196 79 ]
 
         3 ->
             ylorbr3
@@ -4244,10 +4244,10 @@ ylgn n =
             []
 
         1 ->
-            [ rgb 247 252 185 ]
+            [ rgb255 247 252 185 ]
 
         2 ->
-            [ rgb 247 252 185, rgb 173 221 142 ]
+            [ rgb255 247 252 185, rgb255 173 221 142 ]
 
         3 ->
             ylgn3
@@ -4280,10 +4280,10 @@ rdpu n =
             []
 
         1 ->
-            [ rgb 253 224 221 ]
+            [ rgb255 253 224 221 ]
 
         2 ->
-            [ rgb 253 224 221, rgb 250 159 181 ]
+            [ rgb255 253 224 221, rgb255 250 159 181 ]
 
         3 ->
             rdpu3
@@ -4316,10 +4316,10 @@ ylgnbu n =
             []
 
         1 ->
-            [ rgb 237 248 177 ]
+            [ rgb255 237 248 177 ]
 
         2 ->
-            [ rgb 237 248 177, rgb 127 205 187 ]
+            [ rgb255 237 248 177, rgb255 127 205 187 ]
 
         3 ->
             ylgnbu3
@@ -4352,10 +4352,10 @@ gnbu n =
             []
 
         1 ->
-            [ rgb 224 243 219 ]
+            [ rgb255 224 243 219 ]
 
         2 ->
-            [ rgb 224 243 219, rgb 168 221 181 ]
+            [ rgb255 224 243 219, rgb255 168 221 181 ]
 
         3 ->
             gnbu3
@@ -4388,10 +4388,10 @@ ylorrd n =
             []
 
         1 ->
-            [ rgb 255 237 160 ]
+            [ rgb255 255 237 160 ]
 
         2 ->
-            [ rgb 255 237 160, rgb 254 178 76 ]
+            [ rgb255 255 237 160, rgb255 254 178 76 ]
 
         3 ->
             ylorrd3
@@ -4421,10 +4421,10 @@ purd n =
             []
 
         1 ->
-            [ rgb 231 225 239 ]
+            [ rgb255 231 225 239 ]
 
         2 ->
-            [ rgb 231 225 239, rgb 201 148 199 ]
+            [ rgb255 231 225 239, rgb255 201 148 199 ]
 
         3 ->
             purd3
@@ -4457,10 +4457,10 @@ pubugn n =
             []
 
         1 ->
-            [ rgb 236 226 240 ]
+            [ rgb255 236 226 240 ]
 
         2 ->
-            [ rgb 236 226 240, rgb 166 189 219 ]
+            [ rgb255 236 226 240, rgb255 166 189 219 ]
 
         3 ->
             pubugn3

--- a/src/Colorbrewer/SequentialSH.elm
+++ b/src/Colorbrewer/SequentialSH.elm
@@ -6,2065 +6,2065 @@ module Colorbrewer.SequentialSH exposing (oranges3_0, oranges3_1, oranges3_2, or
 
 -}
 
-import Color exposing (Color, rgb)
+import Color exposing (Color, rgb255)
 
 
 {-| Provides the Oranges3 color scheme.
 -}
 oranges3 : List Color
 oranges3 =
-    [ rgb 254 230 206, rgb 253 174 107, rgb 230 85 13 ]
+    [ rgb255 254 230 206, rgb255 253 174 107, rgb255 230 85 13 ]
 
 
 {-| Provides the Oranges3-0 color.
 -}
 oranges3_0 : Color
 oranges3_0 =
-    rgb 254 230 206
+    rgb255 254 230 206
 
 
 {-| Provides the Oranges3-1 color.
 -}
 oranges3_1 : Color
 oranges3_1 =
-    rgb 253 174 107
+    rgb255 253 174 107
 
 
 {-| Provides the Oranges3-2 color.
 -}
 oranges3_2 : Color
 oranges3_2 =
-    rgb 230 85 13
+    rgb255 230 85 13
 
 
 {-| Provides the Oranges4 color scheme.
 -}
 oranges4 : List Color
 oranges4 =
-    [ rgb 254 237 222, rgb 253 190 133, rgb 253 141 60, rgb 217 71 1 ]
+    [ rgb255 254 237 222, rgb255 253 190 133, rgb255 253 141 60, rgb255 217 71 1 ]
 
 
 {-| Provides the Oranges4-0 color.
 -}
 oranges4_0 : Color
 oranges4_0 =
-    rgb 254 237 222
+    rgb255 254 237 222
 
 
 {-| Provides the Oranges4-1 color.
 -}
 oranges4_1 : Color
 oranges4_1 =
-    rgb 253 190 133
+    rgb255 253 190 133
 
 
 {-| Provides the Oranges4-2 color.
 -}
 oranges4_2 : Color
 oranges4_2 =
-    rgb 253 141 60
+    rgb255 253 141 60
 
 
 {-| Provides the Oranges4-3 color.
 -}
 oranges4_3 : Color
 oranges4_3 =
-    rgb 217 71 1
+    rgb255 217 71 1
 
 
 {-| Provides the Oranges5 color scheme.
 -}
 oranges5 : List Color
 oranges5 =
-    [ rgb 254 237 222, rgb 253 190 133, rgb 253 141 60, rgb 230 85 13, rgb 166 54 3 ]
+    [ rgb255 254 237 222, rgb255 253 190 133, rgb255 253 141 60, rgb255 230 85 13, rgb255 166 54 3 ]
 
 
 {-| Provides the Oranges5-0 color.
 -}
 oranges5_0 : Color
 oranges5_0 =
-    rgb 254 237 222
+    rgb255 254 237 222
 
 
 {-| Provides the Oranges5-1 color.
 -}
 oranges5_1 : Color
 oranges5_1 =
-    rgb 253 190 133
+    rgb255 253 190 133
 
 
 {-| Provides the Oranges5-2 color.
 -}
 oranges5_2 : Color
 oranges5_2 =
-    rgb 253 141 60
+    rgb255 253 141 60
 
 
 {-| Provides the Oranges5-3 color.
 -}
 oranges5_3 : Color
 oranges5_3 =
-    rgb 230 85 13
+    rgb255 230 85 13
 
 
 {-| Provides the Oranges5-4 color.
 -}
 oranges5_4 : Color
 oranges5_4 =
-    rgb 166 54 3
+    rgb255 166 54 3
 
 
 {-| Provides the Oranges6 color scheme.
 -}
 oranges6 : List Color
 oranges6 =
-    [ rgb 254 237 222, rgb 253 208 162, rgb 253 174 107, rgb 253 141 60, rgb 230 85 13, rgb 166 54 3 ]
+    [ rgb255 254 237 222, rgb255 253 208 162, rgb255 253 174 107, rgb255 253 141 60, rgb255 230 85 13, rgb255 166 54 3 ]
 
 
 {-| Provides the Oranges6-0 color.
 -}
 oranges6_0 : Color
 oranges6_0 =
-    rgb 254 237 222
+    rgb255 254 237 222
 
 
 {-| Provides the Oranges6-1 color.
 -}
 oranges6_1 : Color
 oranges6_1 =
-    rgb 253 208 162
+    rgb255 253 208 162
 
 
 {-| Provides the Oranges6-2 color.
 -}
 oranges6_2 : Color
 oranges6_2 =
-    rgb 253 174 107
+    rgb255 253 174 107
 
 
 {-| Provides the Oranges6-3 color.
 -}
 oranges6_3 : Color
 oranges6_3 =
-    rgb 253 141 60
+    rgb255 253 141 60
 
 
 {-| Provides the Oranges6-4 color.
 -}
 oranges6_4 : Color
 oranges6_4 =
-    rgb 230 85 13
+    rgb255 230 85 13
 
 
 {-| Provides the Oranges6-5 color.
 -}
 oranges6_5 : Color
 oranges6_5 =
-    rgb 166 54 3
+    rgb255 166 54 3
 
 
 {-| Provides the Oranges7 color scheme.
 -}
 oranges7 : List Color
 oranges7 =
-    [ rgb 254 237 222, rgb 253 208 162, rgb 253 174 107, rgb 253 141 60, rgb 241 105 19, rgb 217 72 1, rgb 140 45 4 ]
+    [ rgb255 254 237 222, rgb255 253 208 162, rgb255 253 174 107, rgb255 253 141 60, rgb255 241 105 19, rgb255 217 72 1, rgb255 140 45 4 ]
 
 
 {-| Provides the Oranges7-0 color.
 -}
 oranges7_0 : Color
 oranges7_0 =
-    rgb 254 237 222
+    rgb255 254 237 222
 
 
 {-| Provides the Oranges7-1 color.
 -}
 oranges7_1 : Color
 oranges7_1 =
-    rgb 253 208 162
+    rgb255 253 208 162
 
 
 {-| Provides the Oranges7-2 color.
 -}
 oranges7_2 : Color
 oranges7_2 =
-    rgb 253 174 107
+    rgb255 253 174 107
 
 
 {-| Provides the Oranges7-3 color.
 -}
 oranges7_3 : Color
 oranges7_3 =
-    rgb 253 141 60
+    rgb255 253 141 60
 
 
 {-| Provides the Oranges7-4 color.
 -}
 oranges7_4 : Color
 oranges7_4 =
-    rgb 241 105 19
+    rgb255 241 105 19
 
 
 {-| Provides the Oranges7-5 color.
 -}
 oranges7_5 : Color
 oranges7_5 =
-    rgb 217 72 1
+    rgb255 217 72 1
 
 
 {-| Provides the Oranges7-6 color.
 -}
 oranges7_6 : Color
 oranges7_6 =
-    rgb 140 45 4
+    rgb255 140 45 4
 
 
 {-| Provides the Oranges8 color scheme.
 -}
 oranges8 : List Color
 oranges8 =
-    [ rgb 255 245 235, rgb 254 230 206, rgb 253 208 162, rgb 253 174 107, rgb 253 141 60, rgb 241 105 19, rgb 217 72 1, rgb 140 45 4 ]
+    [ rgb255 255 245 235, rgb255 254 230 206, rgb255 253 208 162, rgb255 253 174 107, rgb255 253 141 60, rgb255 241 105 19, rgb255 217 72 1, rgb255 140 45 4 ]
 
 
 {-| Provides the Oranges8-0 color.
 -}
 oranges8_0 : Color
 oranges8_0 =
-    rgb 255 245 235
+    rgb255 255 245 235
 
 
 {-| Provides the Oranges8-1 color.
 -}
 oranges8_1 : Color
 oranges8_1 =
-    rgb 254 230 206
+    rgb255 254 230 206
 
 
 {-| Provides the Oranges8-2 color.
 -}
 oranges8_2 : Color
 oranges8_2 =
-    rgb 253 208 162
+    rgb255 253 208 162
 
 
 {-| Provides the Oranges8-3 color.
 -}
 oranges8_3 : Color
 oranges8_3 =
-    rgb 253 174 107
+    rgb255 253 174 107
 
 
 {-| Provides the Oranges8-4 color.
 -}
 oranges8_4 : Color
 oranges8_4 =
-    rgb 253 141 60
+    rgb255 253 141 60
 
 
 {-| Provides the Oranges8-5 color.
 -}
 oranges8_5 : Color
 oranges8_5 =
-    rgb 241 105 19
+    rgb255 241 105 19
 
 
 {-| Provides the Oranges8-6 color.
 -}
 oranges8_6 : Color
 oranges8_6 =
-    rgb 217 72 1
+    rgb255 217 72 1
 
 
 {-| Provides the Oranges8-7 color.
 -}
 oranges8_7 : Color
 oranges8_7 =
-    rgb 140 45 4
+    rgb255 140 45 4
 
 
 {-| Provides the Oranges9 color scheme.
 -}
 oranges9 : List Color
 oranges9 =
-    [ rgb 255 245 235, rgb 254 230 206, rgb 253 208 162, rgb 253 174 107, rgb 253 141 60, rgb 241 105 19, rgb 217 72 1, rgb 166 54 3, rgb 127 39 4 ]
+    [ rgb255 255 245 235, rgb255 254 230 206, rgb255 253 208 162, rgb255 253 174 107, rgb255 253 141 60, rgb255 241 105 19, rgb255 217 72 1, rgb255 166 54 3, rgb255 127 39 4 ]
 
 
 {-| Provides the Oranges9-0 color.
 -}
 oranges9_0 : Color
 oranges9_0 =
-    rgb 255 245 235
+    rgb255 255 245 235
 
 
 {-| Provides the Oranges9-1 color.
 -}
 oranges9_1 : Color
 oranges9_1 =
-    rgb 254 230 206
+    rgb255 254 230 206
 
 
 {-| Provides the Oranges9-2 color.
 -}
 oranges9_2 : Color
 oranges9_2 =
-    rgb 253 208 162
+    rgb255 253 208 162
 
 
 {-| Provides the Oranges9-3 color.
 -}
 oranges9_3 : Color
 oranges9_3 =
-    rgb 253 174 107
+    rgb255 253 174 107
 
 
 {-| Provides the Oranges9-4 color.
 -}
 oranges9_4 : Color
 oranges9_4 =
-    rgb 253 141 60
+    rgb255 253 141 60
 
 
 {-| Provides the Oranges9-5 color.
 -}
 oranges9_5 : Color
 oranges9_5 =
-    rgb 241 105 19
+    rgb255 241 105 19
 
 
 {-| Provides the Oranges9-6 color.
 -}
 oranges9_6 : Color
 oranges9_6 =
-    rgb 217 72 1
+    rgb255 217 72 1
 
 
 {-| Provides the Oranges9-7 color.
 -}
 oranges9_7 : Color
 oranges9_7 =
-    rgb 166 54 3
+    rgb255 166 54 3
 
 
 {-| Provides the Oranges9-8 color.
 -}
 oranges9_8 : Color
 oranges9_8 =
-    rgb 127 39 4
+    rgb255 127 39 4
 
 
 {-| Provides the Reds3 color scheme.
 -}
 reds3 : List Color
 reds3 =
-    [ rgb 254 224 210, rgb 252 146 114, rgb 222 45 38 ]
+    [ rgb255 254 224 210, rgb255 252 146 114, rgb255 222 45 38 ]
 
 
 {-| Provides the Reds3-0 color.
 -}
 reds3_0 : Color
 reds3_0 =
-    rgb 254 224 210
+    rgb255 254 224 210
 
 
 {-| Provides the Reds3-1 color.
 -}
 reds3_1 : Color
 reds3_1 =
-    rgb 252 146 114
+    rgb255 252 146 114
 
 
 {-| Provides the Reds3-2 color.
 -}
 reds3_2 : Color
 reds3_2 =
-    rgb 222 45 38
+    rgb255 222 45 38
 
 
 {-| Provides the Reds4 color scheme.
 -}
 reds4 : List Color
 reds4 =
-    [ rgb 254 229 217, rgb 252 174 145, rgb 251 106 74, rgb 203 24 29 ]
+    [ rgb255 254 229 217, rgb255 252 174 145, rgb255 251 106 74, rgb255 203 24 29 ]
 
 
 {-| Provides the Reds4-0 color.
 -}
 reds4_0 : Color
 reds4_0 =
-    rgb 254 229 217
+    rgb255 254 229 217
 
 
 {-| Provides the Reds4-1 color.
 -}
 reds4_1 : Color
 reds4_1 =
-    rgb 252 174 145
+    rgb255 252 174 145
 
 
 {-| Provides the Reds4-2 color.
 -}
 reds4_2 : Color
 reds4_2 =
-    rgb 251 106 74
+    rgb255 251 106 74
 
 
 {-| Provides the Reds4-3 color.
 -}
 reds4_3 : Color
 reds4_3 =
-    rgb 203 24 29
+    rgb255 203 24 29
 
 
 {-| Provides the Reds5 color scheme.
 -}
 reds5 : List Color
 reds5 =
-    [ rgb 254 229 217, rgb 252 174 145, rgb 251 106 74, rgb 222 45 38, rgb 165 15 21 ]
+    [ rgb255 254 229 217, rgb255 252 174 145, rgb255 251 106 74, rgb255 222 45 38, rgb255 165 15 21 ]
 
 
 {-| Provides the Reds5-0 color.
 -}
 reds5_0 : Color
 reds5_0 =
-    rgb 254 229 217
+    rgb255 254 229 217
 
 
 {-| Provides the Reds5-1 color.
 -}
 reds5_1 : Color
 reds5_1 =
-    rgb 252 174 145
+    rgb255 252 174 145
 
 
 {-| Provides the Reds5-2 color.
 -}
 reds5_2 : Color
 reds5_2 =
-    rgb 251 106 74
+    rgb255 251 106 74
 
 
 {-| Provides the Reds5-3 color.
 -}
 reds5_3 : Color
 reds5_3 =
-    rgb 222 45 38
+    rgb255 222 45 38
 
 
 {-| Provides the Reds5-4 color.
 -}
 reds5_4 : Color
 reds5_4 =
-    rgb 165 15 21
+    rgb255 165 15 21
 
 
 {-| Provides the Reds6 color scheme.
 -}
 reds6 : List Color
 reds6 =
-    [ rgb 254 229 217, rgb 252 187 161, rgb 252 146 114, rgb 251 106 74, rgb 222 45 38, rgb 165 15 21 ]
+    [ rgb255 254 229 217, rgb255 252 187 161, rgb255 252 146 114, rgb255 251 106 74, rgb255 222 45 38, rgb255 165 15 21 ]
 
 
 {-| Provides the Reds6-0 color.
 -}
 reds6_0 : Color
 reds6_0 =
-    rgb 254 229 217
+    rgb255 254 229 217
 
 
 {-| Provides the Reds6-1 color.
 -}
 reds6_1 : Color
 reds6_1 =
-    rgb 252 187 161
+    rgb255 252 187 161
 
 
 {-| Provides the Reds6-2 color.
 -}
 reds6_2 : Color
 reds6_2 =
-    rgb 252 146 114
+    rgb255 252 146 114
 
 
 {-| Provides the Reds6-3 color.
 -}
 reds6_3 : Color
 reds6_3 =
-    rgb 251 106 74
+    rgb255 251 106 74
 
 
 {-| Provides the Reds6-4 color.
 -}
 reds6_4 : Color
 reds6_4 =
-    rgb 222 45 38
+    rgb255 222 45 38
 
 
 {-| Provides the Reds6-5 color.
 -}
 reds6_5 : Color
 reds6_5 =
-    rgb 165 15 21
+    rgb255 165 15 21
 
 
 {-| Provides the Reds7 color scheme.
 -}
 reds7 : List Color
 reds7 =
-    [ rgb 254 229 217, rgb 252 187 161, rgb 252 146 114, rgb 251 106 74, rgb 239 59 44, rgb 203 24 29, rgb 153 0 13 ]
+    [ rgb255 254 229 217, rgb255 252 187 161, rgb255 252 146 114, rgb255 251 106 74, rgb255 239 59 44, rgb255 203 24 29, rgb255 153 0 13 ]
 
 
 {-| Provides the Reds7-0 color.
 -}
 reds7_0 : Color
 reds7_0 =
-    rgb 254 229 217
+    rgb255 254 229 217
 
 
 {-| Provides the Reds7-1 color.
 -}
 reds7_1 : Color
 reds7_1 =
-    rgb 252 187 161
+    rgb255 252 187 161
 
 
 {-| Provides the Reds7-2 color.
 -}
 reds7_2 : Color
 reds7_2 =
-    rgb 252 146 114
+    rgb255 252 146 114
 
 
 {-| Provides the Reds7-3 color.
 -}
 reds7_3 : Color
 reds7_3 =
-    rgb 251 106 74
+    rgb255 251 106 74
 
 
 {-| Provides the Reds7-4 color.
 -}
 reds7_4 : Color
 reds7_4 =
-    rgb 239 59 44
+    rgb255 239 59 44
 
 
 {-| Provides the Reds7-5 color.
 -}
 reds7_5 : Color
 reds7_5 =
-    rgb 203 24 29
+    rgb255 203 24 29
 
 
 {-| Provides the Reds7-6 color.
 -}
 reds7_6 : Color
 reds7_6 =
-    rgb 153 0 13
+    rgb255 153 0 13
 
 
 {-| Provides the Reds8 color scheme.
 -}
 reds8 : List Color
 reds8 =
-    [ rgb 255 245 240, rgb 254 224 210, rgb 252 187 161, rgb 252 146 114, rgb 251 106 74, rgb 239 59 44, rgb 203 24 29, rgb 153 0 13 ]
+    [ rgb255 255 245 240, rgb255 254 224 210, rgb255 252 187 161, rgb255 252 146 114, rgb255 251 106 74, rgb255 239 59 44, rgb255 203 24 29, rgb255 153 0 13 ]
 
 
 {-| Provides the Reds8-0 color.
 -}
 reds8_0 : Color
 reds8_0 =
-    rgb 255 245 240
+    rgb255 255 245 240
 
 
 {-| Provides the Reds8-1 color.
 -}
 reds8_1 : Color
 reds8_1 =
-    rgb 254 224 210
+    rgb255 254 224 210
 
 
 {-| Provides the Reds8-2 color.
 -}
 reds8_2 : Color
 reds8_2 =
-    rgb 252 187 161
+    rgb255 252 187 161
 
 
 {-| Provides the Reds8-3 color.
 -}
 reds8_3 : Color
 reds8_3 =
-    rgb 252 146 114
+    rgb255 252 146 114
 
 
 {-| Provides the Reds8-4 color.
 -}
 reds8_4 : Color
 reds8_4 =
-    rgb 251 106 74
+    rgb255 251 106 74
 
 
 {-| Provides the Reds8-5 color.
 -}
 reds8_5 : Color
 reds8_5 =
-    rgb 239 59 44
+    rgb255 239 59 44
 
 
 {-| Provides the Reds8-6 color.
 -}
 reds8_6 : Color
 reds8_6 =
-    rgb 203 24 29
+    rgb255 203 24 29
 
 
 {-| Provides the Reds8-7 color.
 -}
 reds8_7 : Color
 reds8_7 =
-    rgb 153 0 13
+    rgb255 153 0 13
 
 
 {-| Provides the Reds9 color scheme.
 -}
 reds9 : List Color
 reds9 =
-    [ rgb 255 245 240, rgb 254 224 210, rgb 252 187 161, rgb 252 146 114, rgb 251 106 74, rgb 239 59 44, rgb 203 24 29, rgb 165 15 21, rgb 103 0 13 ]
+    [ rgb255 255 245 240, rgb255 254 224 210, rgb255 252 187 161, rgb255 252 146 114, rgb255 251 106 74, rgb255 239 59 44, rgb255 203 24 29, rgb255 165 15 21, rgb255 103 0 13 ]
 
 
 {-| Provides the Reds9-0 color.
 -}
 reds9_0 : Color
 reds9_0 =
-    rgb 255 245 240
+    rgb255 255 245 240
 
 
 {-| Provides the Reds9-1 color.
 -}
 reds9_1 : Color
 reds9_1 =
-    rgb 254 224 210
+    rgb255 254 224 210
 
 
 {-| Provides the Reds9-2 color.
 -}
 reds9_2 : Color
 reds9_2 =
-    rgb 252 187 161
+    rgb255 252 187 161
 
 
 {-| Provides the Reds9-3 color.
 -}
 reds9_3 : Color
 reds9_3 =
-    rgb 252 146 114
+    rgb255 252 146 114
 
 
 {-| Provides the Reds9-4 color.
 -}
 reds9_4 : Color
 reds9_4 =
-    rgb 251 106 74
+    rgb255 251 106 74
 
 
 {-| Provides the Reds9-5 color.
 -}
 reds9_5 : Color
 reds9_5 =
-    rgb 239 59 44
+    rgb255 239 59 44
 
 
 {-| Provides the Reds9-6 color.
 -}
 reds9_6 : Color
 reds9_6 =
-    rgb 203 24 29
+    rgb255 203 24 29
 
 
 {-| Provides the Reds9-7 color.
 -}
 reds9_7 : Color
 reds9_7 =
-    rgb 165 15 21
+    rgb255 165 15 21
 
 
 {-| Provides the Reds9-8 color.
 -}
 reds9_8 : Color
 reds9_8 =
-    rgb 103 0 13
+    rgb255 103 0 13
 
 
 {-| Provides the Greens3 color scheme.
 -}
 greens3 : List Color
 greens3 =
-    [ rgb 229 245 224, rgb 161 217 155, rgb 49 163 84 ]
+    [ rgb255 229 245 224, rgb255 161 217 155, rgb255 49 163 84 ]
 
 
 {-| Provides the Greens3-0 color.
 -}
 greens3_0 : Color
 greens3_0 =
-    rgb 229 245 224
+    rgb255 229 245 224
 
 
 {-| Provides the Greens3-1 color.
 -}
 greens3_1 : Color
 greens3_1 =
-    rgb 161 217 155
+    rgb255 161 217 155
 
 
 {-| Provides the Greens3-2 color.
 -}
 greens3_2 : Color
 greens3_2 =
-    rgb 49 163 84
+    rgb255 49 163 84
 
 
 {-| Provides the Greens4 color scheme.
 -}
 greens4 : List Color
 greens4 =
-    [ rgb 237 248 233, rgb 186 228 179, rgb 116 196 118, rgb 35 139 69 ]
+    [ rgb255 237 248 233, rgb255 186 228 179, rgb255 116 196 118, rgb255 35 139 69 ]
 
 
 {-| Provides the Greens4-0 color.
 -}
 greens4_0 : Color
 greens4_0 =
-    rgb 237 248 233
+    rgb255 237 248 233
 
 
 {-| Provides the Greens4-1 color.
 -}
 greens4_1 : Color
 greens4_1 =
-    rgb 186 228 179
+    rgb255 186 228 179
 
 
 {-| Provides the Greens4-2 color.
 -}
 greens4_2 : Color
 greens4_2 =
-    rgb 116 196 118
+    rgb255 116 196 118
 
 
 {-| Provides the Greens4-3 color.
 -}
 greens4_3 : Color
 greens4_3 =
-    rgb 35 139 69
+    rgb255 35 139 69
 
 
 {-| Provides the Greens5 color scheme.
 -}
 greens5 : List Color
 greens5 =
-    [ rgb 237 248 233, rgb 186 228 179, rgb 116 196 118, rgb 49 163 84, rgb 0 109 44 ]
+    [ rgb255 237 248 233, rgb255 186 228 179, rgb255 116 196 118, rgb255 49 163 84, rgb255 0 109 44 ]
 
 
 {-| Provides the Greens5-0 color.
 -}
 greens5_0 : Color
 greens5_0 =
-    rgb 237 248 233
+    rgb255 237 248 233
 
 
 {-| Provides the Greens5-1 color.
 -}
 greens5_1 : Color
 greens5_1 =
-    rgb 186 228 179
+    rgb255 186 228 179
 
 
 {-| Provides the Greens5-2 color.
 -}
 greens5_2 : Color
 greens5_2 =
-    rgb 116 196 118
+    rgb255 116 196 118
 
 
 {-| Provides the Greens5-3 color.
 -}
 greens5_3 : Color
 greens5_3 =
-    rgb 49 163 84
+    rgb255 49 163 84
 
 
 {-| Provides the Greens5-4 color.
 -}
 greens5_4 : Color
 greens5_4 =
-    rgb 0 109 44
+    rgb255 0 109 44
 
 
 {-| Provides the Greens6 color scheme.
 -}
 greens6 : List Color
 greens6 =
-    [ rgb 237 248 233, rgb 199 233 192, rgb 161 217 155, rgb 116 196 118, rgb 49 163 84, rgb 0 109 44 ]
+    [ rgb255 237 248 233, rgb255 199 233 192, rgb255 161 217 155, rgb255 116 196 118, rgb255 49 163 84, rgb255 0 109 44 ]
 
 
 {-| Provides the Greens6-0 color.
 -}
 greens6_0 : Color
 greens6_0 =
-    rgb 237 248 233
+    rgb255 237 248 233
 
 
 {-| Provides the Greens6-1 color.
 -}
 greens6_1 : Color
 greens6_1 =
-    rgb 199 233 192
+    rgb255 199 233 192
 
 
 {-| Provides the Greens6-2 color.
 -}
 greens6_2 : Color
 greens6_2 =
-    rgb 161 217 155
+    rgb255 161 217 155
 
 
 {-| Provides the Greens6-3 color.
 -}
 greens6_3 : Color
 greens6_3 =
-    rgb 116 196 118
+    rgb255 116 196 118
 
 
 {-| Provides the Greens6-4 color.
 -}
 greens6_4 : Color
 greens6_4 =
-    rgb 49 163 84
+    rgb255 49 163 84
 
 
 {-| Provides the Greens6-5 color.
 -}
 greens6_5 : Color
 greens6_5 =
-    rgb 0 109 44
+    rgb255 0 109 44
 
 
 {-| Provides the Greens7 color scheme.
 -}
 greens7 : List Color
 greens7 =
-    [ rgb 237 248 233, rgb 199 233 192, rgb 161 217 155, rgb 116 196 118, rgb 65 171 93, rgb 35 139 69, rgb 0 90 50 ]
+    [ rgb255 237 248 233, rgb255 199 233 192, rgb255 161 217 155, rgb255 116 196 118, rgb255 65 171 93, rgb255 35 139 69, rgb255 0 90 50 ]
 
 
 {-| Provides the Greens7-0 color.
 -}
 greens7_0 : Color
 greens7_0 =
-    rgb 237 248 233
+    rgb255 237 248 233
 
 
 {-| Provides the Greens7-1 color.
 -}
 greens7_1 : Color
 greens7_1 =
-    rgb 199 233 192
+    rgb255 199 233 192
 
 
 {-| Provides the Greens7-2 color.
 -}
 greens7_2 : Color
 greens7_2 =
-    rgb 161 217 155
+    rgb255 161 217 155
 
 
 {-| Provides the Greens7-3 color.
 -}
 greens7_3 : Color
 greens7_3 =
-    rgb 116 196 118
+    rgb255 116 196 118
 
 
 {-| Provides the Greens7-4 color.
 -}
 greens7_4 : Color
 greens7_4 =
-    rgb 65 171 93
+    rgb255 65 171 93
 
 
 {-| Provides the Greens7-5 color.
 -}
 greens7_5 : Color
 greens7_5 =
-    rgb 35 139 69
+    rgb255 35 139 69
 
 
 {-| Provides the Greens7-6 color.
 -}
 greens7_6 : Color
 greens7_6 =
-    rgb 0 90 50
+    rgb255 0 90 50
 
 
 {-| Provides the Greens8 color scheme.
 -}
 greens8 : List Color
 greens8 =
-    [ rgb 247 252 245, rgb 229 245 224, rgb 199 233 192, rgb 161 217 155, rgb 116 196 118, rgb 65 171 93, rgb 35 139 69, rgb 0 90 50 ]
+    [ rgb255 247 252 245, rgb255 229 245 224, rgb255 199 233 192, rgb255 161 217 155, rgb255 116 196 118, rgb255 65 171 93, rgb255 35 139 69, rgb255 0 90 50 ]
 
 
 {-| Provides the Greens8-0 color.
 -}
 greens8_0 : Color
 greens8_0 =
-    rgb 247 252 245
+    rgb255 247 252 245
 
 
 {-| Provides the Greens8-1 color.
 -}
 greens8_1 : Color
 greens8_1 =
-    rgb 229 245 224
+    rgb255 229 245 224
 
 
 {-| Provides the Greens8-2 color.
 -}
 greens8_2 : Color
 greens8_2 =
-    rgb 199 233 192
+    rgb255 199 233 192
 
 
 {-| Provides the Greens8-3 color.
 -}
 greens8_3 : Color
 greens8_3 =
-    rgb 161 217 155
+    rgb255 161 217 155
 
 
 {-| Provides the Greens8-4 color.
 -}
 greens8_4 : Color
 greens8_4 =
-    rgb 116 196 118
+    rgb255 116 196 118
 
 
 {-| Provides the Greens8-5 color.
 -}
 greens8_5 : Color
 greens8_5 =
-    rgb 65 171 93
+    rgb255 65 171 93
 
 
 {-| Provides the Greens8-6 color.
 -}
 greens8_6 : Color
 greens8_6 =
-    rgb 35 139 69
+    rgb255 35 139 69
 
 
 {-| Provides the Greens8-7 color.
 -}
 greens8_7 : Color
 greens8_7 =
-    rgb 0 90 50
+    rgb255 0 90 50
 
 
 {-| Provides the Greens9 color scheme.
 -}
 greens9 : List Color
 greens9 =
-    [ rgb 247 252 245, rgb 229 245 224, rgb 199 233 192, rgb 161 217 155, rgb 116 196 118, rgb 65 171 93, rgb 35 139 69, rgb 0 109 44, rgb 0 68 27 ]
+    [ rgb255 247 252 245, rgb255 229 245 224, rgb255 199 233 192, rgb255 161 217 155, rgb255 116 196 118, rgb255 65 171 93, rgb255 35 139 69, rgb255 0 109 44, rgb255 0 68 27 ]
 
 
 {-| Provides the Greens9-0 color.
 -}
 greens9_0 : Color
 greens9_0 =
-    rgb 247 252 245
+    rgb255 247 252 245
 
 
 {-| Provides the Greens9-1 color.
 -}
 greens9_1 : Color
 greens9_1 =
-    rgb 229 245 224
+    rgb255 229 245 224
 
 
 {-| Provides the Greens9-2 color.
 -}
 greens9_2 : Color
 greens9_2 =
-    rgb 199 233 192
+    rgb255 199 233 192
 
 
 {-| Provides the Greens9-3 color.
 -}
 greens9_3 : Color
 greens9_3 =
-    rgb 161 217 155
+    rgb255 161 217 155
 
 
 {-| Provides the Greens9-4 color.
 -}
 greens9_4 : Color
 greens9_4 =
-    rgb 116 196 118
+    rgb255 116 196 118
 
 
 {-| Provides the Greens9-5 color.
 -}
 greens9_5 : Color
 greens9_5 =
-    rgb 65 171 93
+    rgb255 65 171 93
 
 
 {-| Provides the Greens9-6 color.
 -}
 greens9_6 : Color
 greens9_6 =
-    rgb 35 139 69
+    rgb255 35 139 69
 
 
 {-| Provides the Greens9-7 color.
 -}
 greens9_7 : Color
 greens9_7 =
-    rgb 0 109 44
+    rgb255 0 109 44
 
 
 {-| Provides the Greens9-8 color.
 -}
 greens9_8 : Color
 greens9_8 =
-    rgb 0 68 27
+    rgb255 0 68 27
 
 
 {-| Provides the Purples3 color scheme.
 -}
 purples3 : List Color
 purples3 =
-    [ rgb 239 237 245, rgb 188 189 220, rgb 117 107 177 ]
+    [ rgb255 239 237 245, rgb255 188 189 220, rgb255 117 107 177 ]
 
 
 {-| Provides the Purples3-0 color.
 -}
 purples3_0 : Color
 purples3_0 =
-    rgb 239 237 245
+    rgb255 239 237 245
 
 
 {-| Provides the Purples3-1 color.
 -}
 purples3_1 : Color
 purples3_1 =
-    rgb 188 189 220
+    rgb255 188 189 220
 
 
 {-| Provides the Purples3-2 color.
 -}
 purples3_2 : Color
 purples3_2 =
-    rgb 117 107 177
+    rgb255 117 107 177
 
 
 {-| Provides the Purples4 color scheme.
 -}
 purples4 : List Color
 purples4 =
-    [ rgb 242 240 247, rgb 203 201 226, rgb 158 154 200, rgb 106 81 163 ]
+    [ rgb255 242 240 247, rgb255 203 201 226, rgb255 158 154 200, rgb255 106 81 163 ]
 
 
 {-| Provides the Purples4-0 color.
 -}
 purples4_0 : Color
 purples4_0 =
-    rgb 242 240 247
+    rgb255 242 240 247
 
 
 {-| Provides the Purples4-1 color.
 -}
 purples4_1 : Color
 purples4_1 =
-    rgb 203 201 226
+    rgb255 203 201 226
 
 
 {-| Provides the Purples4-2 color.
 -}
 purples4_2 : Color
 purples4_2 =
-    rgb 158 154 200
+    rgb255 158 154 200
 
 
 {-| Provides the Purples4-3 color.
 -}
 purples4_3 : Color
 purples4_3 =
-    rgb 106 81 163
+    rgb255 106 81 163
 
 
 {-| Provides the Purples5 color scheme.
 -}
 purples5 : List Color
 purples5 =
-    [ rgb 242 240 247, rgb 203 201 226, rgb 158 154 200, rgb 117 107 177, rgb 84 39 143 ]
+    [ rgb255 242 240 247, rgb255 203 201 226, rgb255 158 154 200, rgb255 117 107 177, rgb255 84 39 143 ]
 
 
 {-| Provides the Purples5-0 color.
 -}
 purples5_0 : Color
 purples5_0 =
-    rgb 242 240 247
+    rgb255 242 240 247
 
 
 {-| Provides the Purples5-1 color.
 -}
 purples5_1 : Color
 purples5_1 =
-    rgb 203 201 226
+    rgb255 203 201 226
 
 
 {-| Provides the Purples5-2 color.
 -}
 purples5_2 : Color
 purples5_2 =
-    rgb 158 154 200
+    rgb255 158 154 200
 
 
 {-| Provides the Purples5-3 color.
 -}
 purples5_3 : Color
 purples5_3 =
-    rgb 117 107 177
+    rgb255 117 107 177
 
 
 {-| Provides the Purples5-4 color.
 -}
 purples5_4 : Color
 purples5_4 =
-    rgb 84 39 143
+    rgb255 84 39 143
 
 
 {-| Provides the Purples6 color scheme.
 -}
 purples6 : List Color
 purples6 =
-    [ rgb 242 240 247, rgb 218 218 235, rgb 188 189 220, rgb 158 154 200, rgb 117 107 177, rgb 84 39 143 ]
+    [ rgb255 242 240 247, rgb255 218 218 235, rgb255 188 189 220, rgb255 158 154 200, rgb255 117 107 177, rgb255 84 39 143 ]
 
 
 {-| Provides the Purples6-0 color.
 -}
 purples6_0 : Color
 purples6_0 =
-    rgb 242 240 247
+    rgb255 242 240 247
 
 
 {-| Provides the Purples6-1 color.
 -}
 purples6_1 : Color
 purples6_1 =
-    rgb 218 218 235
+    rgb255 218 218 235
 
 
 {-| Provides the Purples6-2 color.
 -}
 purples6_2 : Color
 purples6_2 =
-    rgb 188 189 220
+    rgb255 188 189 220
 
 
 {-| Provides the Purples6-3 color.
 -}
 purples6_3 : Color
 purples6_3 =
-    rgb 158 154 200
+    rgb255 158 154 200
 
 
 {-| Provides the Purples6-4 color.
 -}
 purples6_4 : Color
 purples6_4 =
-    rgb 117 107 177
+    rgb255 117 107 177
 
 
 {-| Provides the Purples6-5 color.
 -}
 purples6_5 : Color
 purples6_5 =
-    rgb 84 39 143
+    rgb255 84 39 143
 
 
 {-| Provides the Purples7 color scheme.
 -}
 purples7 : List Color
 purples7 =
-    [ rgb 242 240 247, rgb 218 218 235, rgb 188 189 220, rgb 158 154 200, rgb 128 125 186, rgb 106 81 163, rgb 74 20 134 ]
+    [ rgb255 242 240 247, rgb255 218 218 235, rgb255 188 189 220, rgb255 158 154 200, rgb255 128 125 186, rgb255 106 81 163, rgb255 74 20 134 ]
 
 
 {-| Provides the Purples7-0 color.
 -}
 purples7_0 : Color
 purples7_0 =
-    rgb 242 240 247
+    rgb255 242 240 247
 
 
 {-| Provides the Purples7-1 color.
 -}
 purples7_1 : Color
 purples7_1 =
-    rgb 218 218 235
+    rgb255 218 218 235
 
 
 {-| Provides the Purples7-2 color.
 -}
 purples7_2 : Color
 purples7_2 =
-    rgb 188 189 220
+    rgb255 188 189 220
 
 
 {-| Provides the Purples7-3 color.
 -}
 purples7_3 : Color
 purples7_3 =
-    rgb 158 154 200
+    rgb255 158 154 200
 
 
 {-| Provides the Purples7-4 color.
 -}
 purples7_4 : Color
 purples7_4 =
-    rgb 128 125 186
+    rgb255 128 125 186
 
 
 {-| Provides the Purples7-5 color.
 -}
 purples7_5 : Color
 purples7_5 =
-    rgb 106 81 163
+    rgb255 106 81 163
 
 
 {-| Provides the Purples7-6 color.
 -}
 purples7_6 : Color
 purples7_6 =
-    rgb 74 20 134
+    rgb255 74 20 134
 
 
 {-| Provides the Purples8 color scheme.
 -}
 purples8 : List Color
 purples8 =
-    [ rgb 252 251 253, rgb 239 237 245, rgb 218 218 235, rgb 188 189 220, rgb 158 154 200, rgb 128 125 186, rgb 106 81 163, rgb 74 20 134 ]
+    [ rgb255 252 251 253, rgb255 239 237 245, rgb255 218 218 235, rgb255 188 189 220, rgb255 158 154 200, rgb255 128 125 186, rgb255 106 81 163, rgb255 74 20 134 ]
 
 
 {-| Provides the Purples8-0 color.
 -}
 purples8_0 : Color
 purples8_0 =
-    rgb 252 251 253
+    rgb255 252 251 253
 
 
 {-| Provides the Purples8-1 color.
 -}
 purples8_1 : Color
 purples8_1 =
-    rgb 239 237 245
+    rgb255 239 237 245
 
 
 {-| Provides the Purples8-2 color.
 -}
 purples8_2 : Color
 purples8_2 =
-    rgb 218 218 235
+    rgb255 218 218 235
 
 
 {-| Provides the Purples8-3 color.
 -}
 purples8_3 : Color
 purples8_3 =
-    rgb 188 189 220
+    rgb255 188 189 220
 
 
 {-| Provides the Purples8-4 color.
 -}
 purples8_4 : Color
 purples8_4 =
-    rgb 158 154 200
+    rgb255 158 154 200
 
 
 {-| Provides the Purples8-5 color.
 -}
 purples8_5 : Color
 purples8_5 =
-    rgb 128 125 186
+    rgb255 128 125 186
 
 
 {-| Provides the Purples8-6 color.
 -}
 purples8_6 : Color
 purples8_6 =
-    rgb 106 81 163
+    rgb255 106 81 163
 
 
 {-| Provides the Purples8-7 color.
 -}
 purples8_7 : Color
 purples8_7 =
-    rgb 74 20 134
+    rgb255 74 20 134
 
 
 {-| Provides the Purples9 color scheme.
 -}
 purples9 : List Color
 purples9 =
-    [ rgb 252 251 253, rgb 239 237 245, rgb 218 218 235, rgb 188 189 220, rgb 158 154 200, rgb 128 125 186, rgb 106 81 163, rgb 84 39 143, rgb 63 0 125 ]
+    [ rgb255 252 251 253, rgb255 239 237 245, rgb255 218 218 235, rgb255 188 189 220, rgb255 158 154 200, rgb255 128 125 186, rgb255 106 81 163, rgb255 84 39 143, rgb255 63 0 125 ]
 
 
 {-| Provides the Purples9-0 color.
 -}
 purples9_0 : Color
 purples9_0 =
-    rgb 252 251 253
+    rgb255 252 251 253
 
 
 {-| Provides the Purples9-1 color.
 -}
 purples9_1 : Color
 purples9_1 =
-    rgb 239 237 245
+    rgb255 239 237 245
 
 
 {-| Provides the Purples9-2 color.
 -}
 purples9_2 : Color
 purples9_2 =
-    rgb 218 218 235
+    rgb255 218 218 235
 
 
 {-| Provides the Purples9-3 color.
 -}
 purples9_3 : Color
 purples9_3 =
-    rgb 188 189 220
+    rgb255 188 189 220
 
 
 {-| Provides the Purples9-4 color.
 -}
 purples9_4 : Color
 purples9_4 =
-    rgb 158 154 200
+    rgb255 158 154 200
 
 
 {-| Provides the Purples9-5 color.
 -}
 purples9_5 : Color
 purples9_5 =
-    rgb 128 125 186
+    rgb255 128 125 186
 
 
 {-| Provides the Purples9-6 color.
 -}
 purples9_6 : Color
 purples9_6 =
-    rgb 106 81 163
+    rgb255 106 81 163
 
 
 {-| Provides the Purples9-7 color.
 -}
 purples9_7 : Color
 purples9_7 =
-    rgb 84 39 143
+    rgb255 84 39 143
 
 
 {-| Provides the Purples9-8 color.
 -}
 purples9_8 : Color
 purples9_8 =
-    rgb 63 0 125
+    rgb255 63 0 125
 
 
 {-| Provides the Greys3 color scheme.
 -}
 greys3 : List Color
 greys3 =
-    [ rgb 240 240 240, rgb 189 189 189, rgb 99 99 99 ]
+    [ rgb255 240 240 240, rgb255 189 189 189, rgb255 99 99 99 ]
 
 
 {-| Provides the Greys3-0 color.
 -}
 greys3_0 : Color
 greys3_0 =
-    rgb 240 240 240
+    rgb255 240 240 240
 
 
 {-| Provides the Greys3-1 color.
 -}
 greys3_1 : Color
 greys3_1 =
-    rgb 189 189 189
+    rgb255 189 189 189
 
 
 {-| Provides the Greys3-2 color.
 -}
 greys3_2 : Color
 greys3_2 =
-    rgb 99 99 99
+    rgb255 99 99 99
 
 
 {-| Provides the Greys4 color scheme.
 -}
 greys4 : List Color
 greys4 =
-    [ rgb 247 247 247, rgb 204 204 204, rgb 150 150 150, rgb 82 82 82 ]
+    [ rgb255 247 247 247, rgb255 204 204 204, rgb255 150 150 150, rgb255 82 82 82 ]
 
 
 {-| Provides the Greys4-0 color.
 -}
 greys4_0 : Color
 greys4_0 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the Greys4-1 color.
 -}
 greys4_1 : Color
 greys4_1 =
-    rgb 204 204 204
+    rgb255 204 204 204
 
 
 {-| Provides the Greys4-2 color.
 -}
 greys4_2 : Color
 greys4_2 =
-    rgb 150 150 150
+    rgb255 150 150 150
 
 
 {-| Provides the Greys4-3 color.
 -}
 greys4_3 : Color
 greys4_3 =
-    rgb 82 82 82
+    rgb255 82 82 82
 
 
 {-| Provides the Greys5 color scheme.
 -}
 greys5 : List Color
 greys5 =
-    [ rgb 247 247 247, rgb 204 204 204, rgb 150 150 150, rgb 99 99 99, rgb 37 37 37 ]
+    [ rgb255 247 247 247, rgb255 204 204 204, rgb255 150 150 150, rgb255 99 99 99, rgb255 37 37 37 ]
 
 
 {-| Provides the Greys5-0 color.
 -}
 greys5_0 : Color
 greys5_0 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the Greys5-1 color.
 -}
 greys5_1 : Color
 greys5_1 =
-    rgb 204 204 204
+    rgb255 204 204 204
 
 
 {-| Provides the Greys5-2 color.
 -}
 greys5_2 : Color
 greys5_2 =
-    rgb 150 150 150
+    rgb255 150 150 150
 
 
 {-| Provides the Greys5-3 color.
 -}
 greys5_3 : Color
 greys5_3 =
-    rgb 99 99 99
+    rgb255 99 99 99
 
 
 {-| Provides the Greys5-4 color.
 -}
 greys5_4 : Color
 greys5_4 =
-    rgb 37 37 37
+    rgb255 37 37 37
 
 
 {-| Provides the Greys6 color scheme.
 -}
 greys6 : List Color
 greys6 =
-    [ rgb 247 247 247, rgb 217 217 217, rgb 189 189 189, rgb 150 150 150, rgb 99 99 99, rgb 37 37 37 ]
+    [ rgb255 247 247 247, rgb255 217 217 217, rgb255 189 189 189, rgb255 150 150 150, rgb255 99 99 99, rgb255 37 37 37 ]
 
 
 {-| Provides the Greys6-0 color.
 -}
 greys6_0 : Color
 greys6_0 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the Greys6-1 color.
 -}
 greys6_1 : Color
 greys6_1 =
-    rgb 217 217 217
+    rgb255 217 217 217
 
 
 {-| Provides the Greys6-2 color.
 -}
 greys6_2 : Color
 greys6_2 =
-    rgb 189 189 189
+    rgb255 189 189 189
 
 
 {-| Provides the Greys6-3 color.
 -}
 greys6_3 : Color
 greys6_3 =
-    rgb 150 150 150
+    rgb255 150 150 150
 
 
 {-| Provides the Greys6-4 color.
 -}
 greys6_4 : Color
 greys6_4 =
-    rgb 99 99 99
+    rgb255 99 99 99
 
 
 {-| Provides the Greys6-5 color.
 -}
 greys6_5 : Color
 greys6_5 =
-    rgb 37 37 37
+    rgb255 37 37 37
 
 
 {-| Provides the Greys7 color scheme.
 -}
 greys7 : List Color
 greys7 =
-    [ rgb 247 247 247, rgb 217 217 217, rgb 189 189 189, rgb 150 150 150, rgb 115 115 115, rgb 82 82 82, rgb 37 37 37 ]
+    [ rgb255 247 247 247, rgb255 217 217 217, rgb255 189 189 189, rgb255 150 150 150, rgb255 115 115 115, rgb255 82 82 82, rgb255 37 37 37 ]
 
 
 {-| Provides the Greys7-0 color.
 -}
 greys7_0 : Color
 greys7_0 =
-    rgb 247 247 247
+    rgb255 247 247 247
 
 
 {-| Provides the Greys7-1 color.
 -}
 greys7_1 : Color
 greys7_1 =
-    rgb 217 217 217
+    rgb255 217 217 217
 
 
 {-| Provides the Greys7-2 color.
 -}
 greys7_2 : Color
 greys7_2 =
-    rgb 189 189 189
+    rgb255 189 189 189
 
 
 {-| Provides the Greys7-3 color.
 -}
 greys7_3 : Color
 greys7_3 =
-    rgb 150 150 150
+    rgb255 150 150 150
 
 
 {-| Provides the Greys7-4 color.
 -}
 greys7_4 : Color
 greys7_4 =
-    rgb 115 115 115
+    rgb255 115 115 115
 
 
 {-| Provides the Greys7-5 color.
 -}
 greys7_5 : Color
 greys7_5 =
-    rgb 82 82 82
+    rgb255 82 82 82
 
 
 {-| Provides the Greys7-6 color.
 -}
 greys7_6 : Color
 greys7_6 =
-    rgb 37 37 37
+    rgb255 37 37 37
 
 
 {-| Provides the Greys8 color scheme.
 -}
 greys8 : List Color
 greys8 =
-    [ rgb 255 255 255, rgb 240 240 240, rgb 217 217 217, rgb 189 189 189, rgb 150 150 150, rgb 115 115 115, rgb 82 82 82, rgb 37 37 37 ]
+    [ rgb255 255 255 255, rgb255 240 240 240, rgb255 217 217 217, rgb255 189 189 189, rgb255 150 150 150, rgb255 115 115 115, rgb255 82 82 82, rgb255 37 37 37 ]
 
 
 {-| Provides the Greys8-0 color.
 -}
 greys8_0 : Color
 greys8_0 =
-    rgb 255 255 255
+    rgb255 255 255 255
 
 
 {-| Provides the Greys8-1 color.
 -}
 greys8_1 : Color
 greys8_1 =
-    rgb 240 240 240
+    rgb255 240 240 240
 
 
 {-| Provides the Greys8-2 color.
 -}
 greys8_2 : Color
 greys8_2 =
-    rgb 217 217 217
+    rgb255 217 217 217
 
 
 {-| Provides the Greys8-3 color.
 -}
 greys8_3 : Color
 greys8_3 =
-    rgb 189 189 189
+    rgb255 189 189 189
 
 
 {-| Provides the Greys8-4 color.
 -}
 greys8_4 : Color
 greys8_4 =
-    rgb 150 150 150
+    rgb255 150 150 150
 
 
 {-| Provides the Greys8-5 color.
 -}
 greys8_5 : Color
 greys8_5 =
-    rgb 115 115 115
+    rgb255 115 115 115
 
 
 {-| Provides the Greys8-6 color.
 -}
 greys8_6 : Color
 greys8_6 =
-    rgb 82 82 82
+    rgb255 82 82 82
 
 
 {-| Provides the Greys8-7 color.
 -}
 greys8_7 : Color
 greys8_7 =
-    rgb 37 37 37
+    rgb255 37 37 37
 
 
 {-| Provides the Greys9 color scheme.
 -}
 greys9 : List Color
 greys9 =
-    [ rgb 255 255 255, rgb 240 240 240, rgb 217 217 217, rgb 189 189 189, rgb 150 150 150, rgb 115 115 115, rgb 82 82 82, rgb 37 37 37, rgb 0 0 0 ]
+    [ rgb255 255 255 255, rgb255 240 240 240, rgb255 217 217 217, rgb255 189 189 189, rgb255 150 150 150, rgb255 115 115 115, rgb255 82 82 82, rgb255 37 37 37, rgb255 0 0 0 ]
 
 
 {-| Provides the Greys9-0 color.
 -}
 greys9_0 : Color
 greys9_0 =
-    rgb 255 255 255
+    rgb255 255 255 255
 
 
 {-| Provides the Greys9-1 color.
 -}
 greys9_1 : Color
 greys9_1 =
-    rgb 240 240 240
+    rgb255 240 240 240
 
 
 {-| Provides the Greys9-2 color.
 -}
 greys9_2 : Color
 greys9_2 =
-    rgb 217 217 217
+    rgb255 217 217 217
 
 
 {-| Provides the Greys9-3 color.
 -}
 greys9_3 : Color
 greys9_3 =
-    rgb 189 189 189
+    rgb255 189 189 189
 
 
 {-| Provides the Greys9-4 color.
 -}
 greys9_4 : Color
 greys9_4 =
-    rgb 150 150 150
+    rgb255 150 150 150
 
 
 {-| Provides the Greys9-5 color.
 -}
 greys9_5 : Color
 greys9_5 =
-    rgb 115 115 115
+    rgb255 115 115 115
 
 
 {-| Provides the Greys9-6 color.
 -}
 greys9_6 : Color
 greys9_6 =
-    rgb 82 82 82
+    rgb255 82 82 82
 
 
 {-| Provides the Greys9-7 color.
 -}
 greys9_7 : Color
 greys9_7 =
-    rgb 37 37 37
+    rgb255 37 37 37
 
 
 {-| Provides the Greys9-8 color.
 -}
 greys9_8 : Color
 greys9_8 =
-    rgb 0 0 0
+    rgb255 0 0 0
 
 
 {-| Provides the Blues3 color scheme.
 -}
 blues3 : List Color
 blues3 =
-    [ rgb 222 235 247, rgb 158 202 225, rgb 49 130 189 ]
+    [ rgb255 222 235 247, rgb255 158 202 225, rgb255 49 130 189 ]
 
 
 {-| Provides the Blues3-0 color.
 -}
 blues3_0 : Color
 blues3_0 =
-    rgb 222 235 247
+    rgb255 222 235 247
 
 
 {-| Provides the Blues3-1 color.
 -}
 blues3_1 : Color
 blues3_1 =
-    rgb 158 202 225
+    rgb255 158 202 225
 
 
 {-| Provides the Blues3-2 color.
 -}
 blues3_2 : Color
 blues3_2 =
-    rgb 49 130 189
+    rgb255 49 130 189
 
 
 {-| Provides the Blues4 color scheme.
 -}
 blues4 : List Color
 blues4 =
-    [ rgb 239 243 255, rgb 189 215 231, rgb 107 174 214, rgb 33 113 181 ]
+    [ rgb255 239 243 255, rgb255 189 215 231, rgb255 107 174 214, rgb255 33 113 181 ]
 
 
 {-| Provides the Blues4-0 color.
 -}
 blues4_0 : Color
 blues4_0 =
-    rgb 239 243 255
+    rgb255 239 243 255
 
 
 {-| Provides the Blues4-1 color.
 -}
 blues4_1 : Color
 blues4_1 =
-    rgb 189 215 231
+    rgb255 189 215 231
 
 
 {-| Provides the Blues4-2 color.
 -}
 blues4_2 : Color
 blues4_2 =
-    rgb 107 174 214
+    rgb255 107 174 214
 
 
 {-| Provides the Blues4-3 color.
 -}
 blues4_3 : Color
 blues4_3 =
-    rgb 33 113 181
+    rgb255 33 113 181
 
 
 {-| Provides the Blues5 color scheme.
 -}
 blues5 : List Color
 blues5 =
-    [ rgb 239 243 255, rgb 189 215 231, rgb 107 174 214, rgb 49 130 189, rgb 8 81 156 ]
+    [ rgb255 239 243 255, rgb255 189 215 231, rgb255 107 174 214, rgb255 49 130 189, rgb255 8 81 156 ]
 
 
 {-| Provides the Blues5-0 color.
 -}
 blues5_0 : Color
 blues5_0 =
-    rgb 239 243 255
+    rgb255 239 243 255
 
 
 {-| Provides the Blues5-1 color.
 -}
 blues5_1 : Color
 blues5_1 =
-    rgb 189 215 231
+    rgb255 189 215 231
 
 
 {-| Provides the Blues5-2 color.
 -}
 blues5_2 : Color
 blues5_2 =
-    rgb 107 174 214
+    rgb255 107 174 214
 
 
 {-| Provides the Blues5-3 color.
 -}
 blues5_3 : Color
 blues5_3 =
-    rgb 49 130 189
+    rgb255 49 130 189
 
 
 {-| Provides the Blues5-4 color.
 -}
 blues5_4 : Color
 blues5_4 =
-    rgb 8 81 156
+    rgb255 8 81 156
 
 
 {-| Provides the Blues6 color scheme.
 -}
 blues6 : List Color
 blues6 =
-    [ rgb 239 243 255, rgb 198 219 239, rgb 158 202 225, rgb 107 174 214, rgb 49 130 189, rgb 8 81 156 ]
+    [ rgb255 239 243 255, rgb255 198 219 239, rgb255 158 202 225, rgb255 107 174 214, rgb255 49 130 189, rgb255 8 81 156 ]
 
 
 {-| Provides the Blues6-0 color.
 -}
 blues6_0 : Color
 blues6_0 =
-    rgb 239 243 255
+    rgb255 239 243 255
 
 
 {-| Provides the Blues6-1 color.
 -}
 blues6_1 : Color
 blues6_1 =
-    rgb 198 219 239
+    rgb255 198 219 239
 
 
 {-| Provides the Blues6-2 color.
 -}
 blues6_2 : Color
 blues6_2 =
-    rgb 158 202 225
+    rgb255 158 202 225
 
 
 {-| Provides the Blues6-3 color.
 -}
 blues6_3 : Color
 blues6_3 =
-    rgb 107 174 214
+    rgb255 107 174 214
 
 
 {-| Provides the Blues6-4 color.
 -}
 blues6_4 : Color
 blues6_4 =
-    rgb 49 130 189
+    rgb255 49 130 189
 
 
 {-| Provides the Blues6-5 color.
 -}
 blues6_5 : Color
 blues6_5 =
-    rgb 8 81 156
+    rgb255 8 81 156
 
 
 {-| Provides the Blues7 color scheme.
 -}
 blues7 : List Color
 blues7 =
-    [ rgb 239 243 255, rgb 198 219 239, rgb 158 202 225, rgb 107 174 214, rgb 66 146 198, rgb 33 113 181, rgb 8 69 148 ]
+    [ rgb255 239 243 255, rgb255 198 219 239, rgb255 158 202 225, rgb255 107 174 214, rgb255 66 146 198, rgb255 33 113 181, rgb255 8 69 148 ]
 
 
 {-| Provides the Blues7-0 color.
 -}
 blues7_0 : Color
 blues7_0 =
-    rgb 239 243 255
+    rgb255 239 243 255
 
 
 {-| Provides the Blues7-1 color.
 -}
 blues7_1 : Color
 blues7_1 =
-    rgb 198 219 239
+    rgb255 198 219 239
 
 
 {-| Provides the Blues7-2 color.
 -}
 blues7_2 : Color
 blues7_2 =
-    rgb 158 202 225
+    rgb255 158 202 225
 
 
 {-| Provides the Blues7-3 color.
 -}
 blues7_3 : Color
 blues7_3 =
-    rgb 107 174 214
+    rgb255 107 174 214
 
 
 {-| Provides the Blues7-4 color.
 -}
 blues7_4 : Color
 blues7_4 =
-    rgb 66 146 198
+    rgb255 66 146 198
 
 
 {-| Provides the Blues7-5 color.
 -}
 blues7_5 : Color
 blues7_5 =
-    rgb 33 113 181
+    rgb255 33 113 181
 
 
 {-| Provides the Blues7-6 color.
 -}
 blues7_6 : Color
 blues7_6 =
-    rgb 8 69 148
+    rgb255 8 69 148
 
 
 {-| Provides the Blues8 color scheme.
 -}
 blues8 : List Color
 blues8 =
-    [ rgb 247 251 255, rgb 222 235 247, rgb 198 219 239, rgb 158 202 225, rgb 107 174 214, rgb 66 146 198, rgb 33 113 181, rgb 8 69 148 ]
+    [ rgb255 247 251 255, rgb255 222 235 247, rgb255 198 219 239, rgb255 158 202 225, rgb255 107 174 214, rgb255 66 146 198, rgb255 33 113 181, rgb255 8 69 148 ]
 
 
 {-| Provides the Blues8-0 color.
 -}
 blues8_0 : Color
 blues8_0 =
-    rgb 247 251 255
+    rgb255 247 251 255
 
 
 {-| Provides the Blues8-1 color.
 -}
 blues8_1 : Color
 blues8_1 =
-    rgb 222 235 247
+    rgb255 222 235 247
 
 
 {-| Provides the Blues8-2 color.
 -}
 blues8_2 : Color
 blues8_2 =
-    rgb 198 219 239
+    rgb255 198 219 239
 
 
 {-| Provides the Blues8-3 color.
 -}
 blues8_3 : Color
 blues8_3 =
-    rgb 158 202 225
+    rgb255 158 202 225
 
 
 {-| Provides the Blues8-4 color.
 -}
 blues8_4 : Color
 blues8_4 =
-    rgb 107 174 214
+    rgb255 107 174 214
 
 
 {-| Provides the Blues8-5 color.
 -}
 blues8_5 : Color
 blues8_5 =
-    rgb 66 146 198
+    rgb255 66 146 198
 
 
 {-| Provides the Blues8-6 color.
 -}
 blues8_6 : Color
 blues8_6 =
-    rgb 33 113 181
+    rgb255 33 113 181
 
 
 {-| Provides the Blues8-7 color.
 -}
 blues8_7 : Color
 blues8_7 =
-    rgb 8 69 148
+    rgb255 8 69 148
 
 
 {-| Provides the Blues9 color scheme.
 -}
 blues9 : List Color
 blues9 =
-    [ rgb 247 251 255, rgb 222 235 247, rgb 198 219 239, rgb 158 202 225, rgb 107 174 214, rgb 66 146 198, rgb 33 113 181, rgb 8 81 156, rgb 8 48 107 ]
+    [ rgb255 247 251 255, rgb255 222 235 247, rgb255 198 219 239, rgb255 158 202 225, rgb255 107 174 214, rgb255 66 146 198, rgb255 33 113 181, rgb255 8 81 156, rgb255 8 48 107 ]
 
 
 {-| Provides the Blues9-0 color.
 -}
 blues9_0 : Color
 blues9_0 =
-    rgb 247 251 255
+    rgb255 247 251 255
 
 
 {-| Provides the Blues9-1 color.
 -}
 blues9_1 : Color
 blues9_1 =
-    rgb 222 235 247
+    rgb255 222 235 247
 
 
 {-| Provides the Blues9-2 color.
 -}
 blues9_2 : Color
 blues9_2 =
-    rgb 198 219 239
+    rgb255 198 219 239
 
 
 {-| Provides the Blues9-3 color.
 -}
 blues9_3 : Color
 blues9_3 =
-    rgb 158 202 225
+    rgb255 158 202 225
 
 
 {-| Provides the Blues9-4 color.
 -}
 blues9_4 : Color
 blues9_4 =
-    rgb 107 174 214
+    rgb255 107 174 214
 
 
 {-| Provides the Blues9-5 color.
 -}
 blues9_5 : Color
 blues9_5 =
-    rgb 66 146 198
+    rgb255 66 146 198
 
 
 {-| Provides the Blues9-6 color.
 -}
 blues9_6 : Color
 blues9_6 =
-    rgb 33 113 181
+    rgb255 33 113 181
 
 
 {-| Provides the Blues9-7 color.
 -}
 blues9_7 : Color
 blues9_7 =
-    rgb 8 81 156
+    rgb255 8 81 156
 
 
 {-| Provides the Blues9-8 color.
 -}
 blues9_8 : Color
 blues9_8 =
-    rgb 8 48 107
+    rgb255 8 48 107
 
 
 {-| Returns a Oranges color scheme.
@@ -2076,10 +2076,10 @@ oranges n =
             []
 
         1 ->
-            [ rgb 254 230 206 ]
+            [ rgb255 254 230 206 ]
 
         2 ->
-            [ rgb 254 230 206, rgb 253 174 107 ]
+            [ rgb255 254 230 206, rgb255 253 174 107 ]
 
         3 ->
             oranges3
@@ -2112,10 +2112,10 @@ reds n =
             []
 
         1 ->
-            [ rgb 254 224 210 ]
+            [ rgb255 254 224 210 ]
 
         2 ->
-            [ rgb 254 224 210, rgb 252 146 114 ]
+            [ rgb255 254 224 210, rgb255 252 146 114 ]
 
         3 ->
             reds3
@@ -2148,10 +2148,10 @@ greens n =
             []
 
         1 ->
-            [ rgb 229 245 224 ]
+            [ rgb255 229 245 224 ]
 
         2 ->
-            [ rgb 229 245 224, rgb 161 217 155 ]
+            [ rgb255 229 245 224, rgb255 161 217 155 ]
 
         3 ->
             greens3
@@ -2184,10 +2184,10 @@ purples n =
             []
 
         1 ->
-            [ rgb 239 237 245 ]
+            [ rgb255 239 237 245 ]
 
         2 ->
-            [ rgb 239 237 245, rgb 188 189 220 ]
+            [ rgb255 239 237 245, rgb255 188 189 220 ]
 
         3 ->
             purples3
@@ -2220,10 +2220,10 @@ greys n =
             []
 
         1 ->
-            [ rgb 240 240 240 ]
+            [ rgb255 240 240 240 ]
 
         2 ->
-            [ rgb 240 240 240, rgb 189 189 189 ]
+            [ rgb255 240 240 240, rgb255 189 189 189 ]
 
         3 ->
             greys3
@@ -2256,10 +2256,10 @@ blues n =
             []
 
         1 ->
-            [ rgb 222 235 247 ]
+            [ rgb255 222 235 247 ]
 
         2 ->
-            [ rgb 222 235 247, rgb 158 202 225 ]
+            [ rgb255 222 235 247, rgb255 158 202 225 ]
 
         3 ->
             blues3

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,30 +7,406 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.8.tgz#e5d71173c95533be9842b2c798978f095f912aab"
   integrity sha512-szA3x/3miL90ZJxUCzx9haNbK5/zmPieGraZEe4WI+3srN0eGLiT22NXeMHmyhNEopn+IrxqMc7wdVwvPl8meg==
 
+ajv@^6.5.5:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 arg@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.0.tgz#583c518199419e0037abb74062c37f8519e575f0"
   integrity sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==
+
+asn1@~0.2.3:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+  integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
+  dependencies:
+    safer-buffer "~2.1.0"
+
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
+
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+bcrypt-pbkdf@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
+  dependencies:
+    tweetnacl "^0.14.3"
+
+binary@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
+  integrity sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=
+  dependencies:
+    buffers "~0.1.1"
+    chainsaw "~0.1.0"
+
+binwrap@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/binwrap/-/binwrap-0.2.1.tgz#d88467026170cb2776b9d47f002d3b4316aa9a87"
+  integrity sha512-kILc2+zMfFEv66/NLfO2GIpmWRPE8hL68fv+o5A94OlN9AIIG4zernpgn9bpPAImb5t4QwFxnqAGSyP1+tGKrA==
+  dependencies:
+    mustache "^2.3.0"
+    request "^2.87.0"
+    request-promise "^4.2.0"
+    tar "^4.4.8"
+    unzip-stream "^0.3.0"
+
+bluebird@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
+  integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
 
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+buffers@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
+  integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
+
+caseless@~0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chainsaw@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
+  integrity sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=
+  dependencies:
+    traverse ">=0.3.0 <0.4"
+
+chownr@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
+  integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
+
+combined-stream@^1.0.6, combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
+  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
+  dependencies:
+    delayed-stream "~1.0.0"
+
+core-util-is@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+  integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+dashdash@^1.12.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
+  dependencies:
+    assert-plus "^1.0.0"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
 diff@^3.1.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+ecc-jsbn@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
+  dependencies:
+    jsbn "~0.1.0"
+    safer-buffer "^2.1.0"
+
+elm-format@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/elm-format/-/elm-format-0.8.1.tgz#37796fc06b8460a6d76a054a1216d86d8481155e"
+  integrity sha512-uLcDICdmEoRBaCp3PobcvHtUej2RJFHRYfMd7i3CSH+RsajJYTdiPkviKIq823Kd4gfjQMpNajEyM1lLFez7+A==
+  dependencies:
+    binwrap "^0.2.0"
+
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+extsprintf@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
+
+extsprintf@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+  integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+
+forever-agent@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+  integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
+  dependencies:
+    minipass "^2.2.1"
+
+getpass@^0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
+  dependencies:
+    assert-plus "^1.0.0"
+
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
+
+har-validator@~5.1.0:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
+  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
+  dependencies:
+    ajv "^6.5.5"
+    har-schema "^2.0.0"
+
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
+is-typedarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+isstream@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+jsbn@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+  integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+
+json-stringify-safe@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
+jsprim@^1.2.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+  integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
+  dependencies:
+    assert-plus "1.0.0"
+    extsprintf "1.3.0"
+    json-schema "0.2.3"
+    verror "1.10.0"
+
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 make-error@^1.1.1:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
   integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
 
+mime-db@1.40.0:
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
+  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+
+mime-types@^2.1.12, mime-types@~2.1.19:
+  version "2.1.24"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
+  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
+  dependencies:
+    mime-db "1.40.0"
+
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
+minipass@^2.2.1, minipass@^2.3.4:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
+  integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+  integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
+  dependencies:
+    minipass "^2.2.1"
+
+mkdirp@^0.5.0, mkdirp@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  dependencies:
+    minimist "0.0.8"
+
+mustache@^2.3.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
+  integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
 prettier@^1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
   integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
+
+psl@^1.1.24, psl@^1.1.28:
+  version "1.1.31"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
+  integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
+
+punycode@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
+
+punycode@^2.1.0, punycode@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+qs@~6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+request-promise-core@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
+  integrity sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==
+  dependencies:
+    lodash "^4.17.11"
+
+request-promise@^4.2.0:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.4.tgz#1c5ed0d71441e38ad58c7ce4ea4ea5b06d54b310"
+  integrity sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==
+  dependencies:
+    bluebird "^3.5.0"
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
+
+request@^2.87.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 source-map-support@^0.5.6:
   version "0.5.12"
@@ -45,6 +421,60 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+sshpk@^1.7.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
+  integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
+  dependencies:
+    asn1 "~0.2.3"
+    assert-plus "^1.0.0"
+    bcrypt-pbkdf "^1.0.0"
+    dashdash "^1.12.0"
+    ecc-jsbn "~0.1.1"
+    getpass "^0.1.1"
+    jsbn "~0.1.0"
+    safer-buffer "^2.0.2"
+    tweetnacl "~0.14.0"
+
+stealthy-require@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+  integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+tar@^4.4.8:
+  version "4.4.8"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
+  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.4"
+    minizlib "^1.1.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
+
+tough-cookie@^2.3.3:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
+tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
+"traverse@>=0.3.0 <0.4":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
+  integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
+
 ts-node@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.1.0.tgz#8c4b37036abd448577db22a061fd7a67d47e658e"
@@ -56,10 +486,56 @@ ts-node@^8.1.0:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
+  dependencies:
+    safe-buffer "^5.0.1"
+
+tweetnacl@^0.14.3, tweetnacl@~0.14.0:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
 typescript@^3.4.5:
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
   integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+
+unzip-stream@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/unzip-stream/-/unzip-stream-0.3.0.tgz#c30c054cd6b0d64b13a23cd3ece911eb0b2b52d8"
+  integrity sha512-NG1h/MdGIX3HzyqMjyj1laBCmlPYhcO4xEy7gEqqzGiSLw7XqDQCnY4nYSn5XSaH8mQ6TFkaujrO8d/PIZN85A==
+  dependencies:
+    binary "^0.3.0"
+    mkdirp "^0.5.1"
+
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+verror@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
+
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
+  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
 
 yn@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
I've also installed `elm-format` locally with yarn, since I didn't have that globally, and I expect
the version you run should be the same for all developers.
Let me know and I'll remove that if you disagree.
This solves https://github.com/dawehner/elm-colorbrewer/issues/5